### PR TITLE
Add adapter modules for LLM providers

### DIFF
--- a/shared/llm/adapters/__init__.py
+++ b/shared/llm/adapters/__init__.py
@@ -1,0 +1,18 @@
+"""Provider-specific adapter helpers for language model clients."""
+
+from . import anthropic, azure, openai, vertex
+from .anthropic import get_chat_model as get_anthropic_chat_model
+from .azure import get_chat_model as get_azure_chat_model
+from .openai import get_chat_model as get_openai_chat_model
+from .vertex import get_chat_model as get_vertex_chat_model
+
+__all__ = [
+    "anthropic",
+    "azure",
+    "openai",
+    "vertex",
+    "get_anthropic_chat_model",
+    "get_azure_chat_model",
+    "get_openai_chat_model",
+    "get_vertex_chat_model",
+]

--- a/shared/llm/adapters/_base.py
+++ b/shared/llm/adapters/_base.py
@@ -1,0 +1,38 @@
+"""Shared utilities for LLM adapter implementations."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from shared.config.settings import Settings, get_settings
+
+try:  # pragma: no cover - optional dependency shim
+    from langchain_core.language_models import BaseLanguageModel
+except ImportError:  # pragma: no cover
+    try:
+        from langchain.schema.language_model import BaseLanguageModel  # type: ignore
+    except ImportError:  # pragma: no cover
+        BaseLanguageModel = Any  # type: ignore[misc,assignment]
+
+DEFAULT_MAX_RETRIES = 3
+
+
+def resolve_settings(settings: Optional[Settings]) -> Settings:
+    """Return provided settings or fall back to application defaults."""
+
+    return settings or get_settings()
+
+
+def apply_temperature(kwargs: Dict[str, Any], temperature: Optional[float]) -> None:
+    """Attach ``temperature`` to ``kwargs`` when explicitly supplied."""
+
+    if temperature is not None:
+        kwargs["temperature"] = float(temperature)
+
+
+__all__ = [
+    "BaseLanguageModel",
+    "DEFAULT_MAX_RETRIES",
+    "resolve_settings",
+    "apply_temperature",
+]

--- a/shared/llm/adapters/azure.py
+++ b/shared/llm/adapters/azure.py
@@ -1,0 +1,91 @@
+"""Adapter for configuring Azure OpenAI chat models."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from fastapi import HTTPException
+
+from shared.config.settings import Settings
+
+from ._base import (
+    BaseLanguageModel,
+    DEFAULT_MAX_RETRIES,
+    apply_temperature,
+    resolve_settings,
+)
+
+try:  # pragma: no cover - optional dependency shim
+    from langchain.chat_models import AzureChatOpenAI
+except ImportError as exc:  # pragma: no cover
+    try:
+        from langchain_openai import AzureChatOpenAI  # type: ignore
+    except ImportError:  # pragma: no cover
+        raise RuntimeError(
+            "Azure OpenAI chat support requires the LangChain OpenAI integration."
+        ) from exc
+
+
+def get_chat_model(
+    model_name: str,
+    *,
+    settings: Optional[Settings] = None,
+    temperature: Optional[float] = None,
+    has_explicit_model_override: bool = False,
+) -> BaseLanguageModel:
+    """Return a configured Azure OpenAI chat model instance."""
+
+    resolved_settings = resolve_settings(settings)
+    azure_settings = resolved_settings.azure
+    api_key = (azure_settings.api_key or "").strip()
+    endpoint = (azure_settings.endpoint or "").strip()
+    if not api_key:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "Azure OpenAI API key is not configured. Set the AZURE_API_KEY "
+                "environment variable to enable Azure-backed models."
+            ),
+        )
+    if not endpoint:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "Azure OpenAI endpoint is not configured. Set the AZURE_ENDPOINT "
+                "environment variable to enable Azure-backed models."
+            ),
+        )
+
+    deployment_name = model_name
+    if not has_explicit_model_override and azure_settings.deployment_name:
+        deployment_name = azure_settings.deployment_name
+    deployment_name = (deployment_name or "").strip()
+    if not deployment_name:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "Azure OpenAI deployment name is not configured. Provide either an "
+                "explicit model override or set AZURE_DEPLOYMENT_NAME."
+            ),
+        )
+
+    kwargs: Dict[str, Any] = {
+        "azure_deployment": deployment_name,
+        "deployment_name": deployment_name,
+        "api_key": api_key,
+        "openai_api_key": api_key,
+        "azure_endpoint": endpoint,
+        "openai_api_base": endpoint,
+        "base_url": endpoint,
+        "max_retries": DEFAULT_MAX_RETRIES,
+    }
+    apply_temperature(kwargs, temperature)
+
+    if azure_settings.api_version:
+        kwargs["openai_api_version"] = azure_settings.api_version
+        kwargs["api_version"] = azure_settings.api_version
+
+    return AzureChatOpenAI(**kwargs)
+
+
+__all__ = ["get_chat_model"]

--- a/shared/llm/adapters/openai.py
+++ b/shared/llm/adapters/openai.py
@@ -1,0 +1,70 @@
+"""Adapter for configuring OpenAI chat models."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from fastapi import HTTPException
+
+from shared.config.settings import Settings
+
+from ._base import (
+    BaseLanguageModel,
+    DEFAULT_MAX_RETRIES,
+    apply_temperature,
+    resolve_settings,
+)
+
+try:  # pragma: no cover - optional dependency shim
+    from langchain.chat_models import ChatOpenAI
+except ImportError as exc:  # pragma: no cover
+    try:
+        from langchain_openai import ChatOpenAI  # type: ignore
+    except ImportError:  # pragma: no cover
+        raise RuntimeError(
+            "OpenAI chat support requires the LangChain OpenAI integration."
+        ) from exc
+
+
+def get_chat_model(
+    model_name: str,
+    *,
+    settings: Optional[Settings] = None,
+    temperature: Optional[float] = None,
+) -> BaseLanguageModel:
+    """Return a configured OpenAI chat model instance."""
+
+    resolved_settings = resolve_settings(settings)
+    openai_settings = resolved_settings.openai
+    api_key = (openai_settings.api_key or "").strip()
+    if not api_key:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "OpenAI API key is not configured. Set the OPENAI_API_KEY environment "
+                "variable to enable OpenAI chat models."
+            ),
+        )
+
+    kwargs: Dict[str, Any] = {
+        "model_name": model_name,
+        "model": model_name,
+        "api_key": api_key,
+        "openai_api_key": api_key,
+        "max_retries": DEFAULT_MAX_RETRIES,
+    }
+    apply_temperature(kwargs, temperature)
+
+    if openai_settings.organization:
+        kwargs["organization"] = openai_settings.organization
+        kwargs["openai_organization"] = openai_settings.organization
+    if openai_settings.project:
+        kwargs["project"] = openai_settings.project
+    if openai_settings.base_url:
+        kwargs["base_url"] = openai_settings.base_url
+        kwargs["openai_api_base"] = openai_settings.base_url
+
+    return ChatOpenAI(**kwargs)
+
+
+__all__ = ["get_chat_model"]

--- a/shared/llm/adapters/vertex.py
+++ b/shared/llm/adapters/vertex.py
@@ -1,0 +1,121 @@
+"""Adapter for configuring Google Vertex AI chat models."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fastapi import HTTPException
+
+from shared.config.settings import Settings
+
+from ._base import (
+    BaseLanguageModel,
+    DEFAULT_MAX_RETRIES,
+    apply_temperature,
+    resolve_settings,
+)
+
+try:  # pragma: no cover - optional dependency shim
+    from langchain.chat_models import ChatVertexAI
+except ImportError as exc:  # pragma: no cover
+    try:
+        from langchain_google_vertexai import ChatVertexAI  # type: ignore
+    except ImportError:  # pragma: no cover
+        raise RuntimeError(
+            "Google Vertex AI support requires the langchain-google-vertexai package."
+        ) from exc
+
+
+def _resolve_credentials_path(explicit_path: Optional[str]) -> Optional[str]:
+    """Determine a usable credentials file path if one is available."""
+
+    if explicit_path and explicit_path.strip():
+        expanded = Path(explicit_path).expanduser()
+        if not expanded.exists():
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    "Vertex AI credentials file configured in VERTEX_CREDENTIALS_FILE does "
+                    "not exist."
+                ),
+            )
+        return str(expanded)
+
+    env_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if env_path and env_path.strip():
+        expanded = Path(env_path).expanduser()
+        if not expanded.exists():
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    "Vertex AI credentials file referenced by GOOGLE_APPLICATION_CREDENTIALS "
+                    "does not exist."
+                ),
+            )
+        return str(expanded)
+
+    return None
+
+
+def get_chat_model(
+    model_name: str,
+    *,
+    settings: Optional[Settings] = None,
+    temperature: Optional[float] = None,
+    has_explicit_model_override: bool = False,
+) -> BaseLanguageModel:
+    """Return a configured Vertex AI chat model instance."""
+
+    resolved_settings = resolve_settings(settings)
+    vertex_settings = resolved_settings.vertex
+    project_id = (vertex_settings.project_id or "").strip()
+    location = (vertex_settings.location or "").strip()
+
+    if not project_id:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "Vertex AI project ID is not configured. Set the VERTEX_PROJECT_ID "
+                "environment variable to enable Gemini models."
+            ),
+        )
+    if not location:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "Vertex AI location is not configured. Set the VERTEX_LOCATION environment "
+                "variable to enable Gemini models."
+            ),
+        )
+
+    resolved_model_name = model_name
+    if not has_explicit_model_override and vertex_settings.model:
+        resolved_model_name = vertex_settings.model
+
+    credentials_path = _resolve_credentials_path(vertex_settings.credentials_file)
+    if credentials_path is None and not os.environ.get("GOOGLE_CLOUD_PROJECT"):
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "Vertex AI credentials are not configured. Provide VERTEX_CREDENTIALS_FILE "
+                "or set GOOGLE_APPLICATION_CREDENTIALS to a service account key."
+            ),
+        )
+
+    kwargs: Dict[str, Any] = {
+        "model_name": resolved_model_name,
+        "project": project_id,
+        "location": location,
+        "max_retries": DEFAULT_MAX_RETRIES,
+    }
+    apply_temperature(kwargs, temperature)
+
+    if credentials_path:
+        kwargs["credentials_path"] = credentials_path
+
+    return ChatVertexAI(**kwargs)
+
+
+__all__ = ["get_chat_model"]

--- a/shared/llm/providers.py
+++ b/shared/llm/providers.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import Any, Optional
 
 from shared.config.settings import Settings
+from .adapters import (
+    anthropic as anthropic_adapter,
+    azure as azure_adapter,
+    openai as openai_adapter,
+    vertex as vertex_adapter,
+)
 
 try:  # pragma: no cover - runtime dependency optional during type checking
     from langchain_core.language_models import BaseLanguageModel
@@ -14,9 +20,6 @@ except ImportError:  # pragma: no cover
         from langchain.schema.language_model import BaseLanguageModel  # type: ignore
     except ImportError:  # pragma: no cover
         BaseLanguageModel = Any  # type: ignore[misc,assignment]
-
-if TYPE_CHECKING:  # pragma: no cover
-    from .llmmodels import ModelSpec
 
 
 class LLMProvider(str, Enum):
@@ -70,165 +73,33 @@ class LLMProvider(str, Enum):
         backend = spec.backend.lower()
 
         if backend == "openai":
-            return _build_openai_client(settings, spec.model_name, resolved_temperature)
+            return openai_adapter.get_chat_model(
+                spec.model_name,
+                settings=settings,
+                temperature=resolved_temperature,
+            )
         if backend == "azure":
-            return _build_azure_client(settings, spec, resolved_temperature, has_override)
+            return azure_adapter.get_chat_model(
+                spec.model_name,
+                settings=settings,
+                temperature=resolved_temperature,
+                has_explicit_model_override=has_override,
+            )
         if backend == "anthropic":
-            return _build_anthropic_client(settings, spec.model_name, resolved_temperature)
+            return anthropic_adapter.get_chat_model(
+                spec.model_name,
+                settings=settings,
+                temperature=resolved_temperature,
+            )
         if backend in {"vertex", "gemini", "google"}:
-            return _build_vertex_client(settings, spec, resolved_temperature, has_override)
+            return vertex_adapter.get_chat_model(
+                spec.model_name,
+                settings=settings,
+                temperature=resolved_temperature,
+                has_explicit_model_override=has_override,
+            )
 
         raise ValueError(f"Unsupported LLM backend '{spec.backend}' for provider {self.value}.")
-
-
-def _maybe_add_temperature(kwargs: Dict[str, Any], temperature: Optional[float]) -> None:
-    """Attach ``temperature`` to ``kwargs`` when explicitly provided."""
-
-    if temperature is not None:
-        kwargs["temperature"] = float(temperature)
-
-
-def _build_openai_client(
-    settings: Settings,
-    model_name: str,
-    temperature: Optional[float],
-) -> BaseLanguageModel:
-    """Create a ChatOpenAI client instance."""
-
-    try:  # pragma: no cover - import depends on optional extras
-        from langchain.chat_models import ChatOpenAI
-    except ImportError as exc:  # pragma: no cover
-        try:
-            from langchain_openai import ChatOpenAI  # type: ignore
-        except ImportError:
-            raise RuntimeError(
-                "OpenAI chat support requires the LangChain OpenAI integration."
-            ) from exc
-
-    openai_settings = settings.openai
-    kwargs: Dict[str, Any] = {
-        "model_name": model_name,
-        "model": model_name,
-    }
-    _maybe_add_temperature(kwargs, temperature)
-    if openai_settings.api_key:
-        kwargs["api_key"] = openai_settings.api_key
-        kwargs["openai_api_key"] = openai_settings.api_key
-    if openai_settings.organization:
-        kwargs["organization"] = openai_settings.organization
-        kwargs["openai_organization"] = openai_settings.organization
-    if openai_settings.project:
-        kwargs["project"] = openai_settings.project
-    if openai_settings.base_url:
-        kwargs["base_url"] = openai_settings.base_url
-        kwargs["openai_api_base"] = openai_settings.base_url
-    return ChatOpenAI(**kwargs)
-
-
-def _build_azure_client(
-    settings: Settings,
-    spec: "ModelSpec",
-    temperature: Optional[float],
-    has_override: bool,
-) -> BaseLanguageModel:
-    """Create an Azure OpenAI chat client instance."""
-
-    try:  # pragma: no cover - optional dependency
-        from langchain.chat_models import AzureChatOpenAI
-    except ImportError as exc:  # pragma: no cover
-        try:
-            from langchain_openai import AzureChatOpenAI  # type: ignore
-        except ImportError:
-            raise RuntimeError(
-                "Azure OpenAI chat support requires the LangChain OpenAI integration."
-            ) from exc
-
-    azure_settings = settings.azure
-    deployment = spec.model_name
-    if not has_override and azure_settings.deployment_name:
-        deployment = azure_settings.deployment_name
-    if not deployment:
-        raise ValueError("Azure OpenAI deployment name is required to build a client.")
-
-    kwargs: Dict[str, Any] = {
-        "azure_deployment": deployment,
-        "deployment_name": deployment,
-    }
-    _maybe_add_temperature(kwargs, temperature)
-    if azure_settings.api_key:
-        kwargs["api_key"] = azure_settings.api_key
-        kwargs["openai_api_key"] = azure_settings.api_key
-    if azure_settings.endpoint:
-        kwargs["azure_endpoint"] = azure_settings.endpoint
-        kwargs["openai_api_base"] = azure_settings.endpoint
-        kwargs["base_url"] = azure_settings.endpoint
-    if azure_settings.api_version:
-        kwargs["openai_api_version"] = azure_settings.api_version
-        kwargs["api_version"] = azure_settings.api_version
-    return AzureChatOpenAI(**kwargs)
-
-
-def _build_anthropic_client(
-    settings: Settings,
-    model_name: str,
-    temperature: Optional[float],
-) -> BaseLanguageModel:
-    """Create a ChatAnthropic client instance."""
-
-    try:  # pragma: no cover - optional dependency
-        from langchain.chat_models import ChatAnthropic
-    except ImportError as exc:  # pragma: no cover
-        try:
-            from langchain_anthropic import ChatAnthropic  # type: ignore
-        except ImportError:
-            raise RuntimeError(
-                "Anthropic chat support requires the LangChain Anthropic integration."
-            ) from exc
-
-    anthropic_settings = settings.anthropic
-    kwargs: Dict[str, Any] = {"model": model_name}
-    _maybe_add_temperature(kwargs, temperature)
-    if anthropic_settings.api_key:
-        kwargs["api_key"] = anthropic_settings.api_key
-        kwargs["anthropic_api_key"] = anthropic_settings.api_key
-    if anthropic_settings.base_url:
-        kwargs["base_url"] = anthropic_settings.base_url
-        kwargs["anthropic_api_url"] = anthropic_settings.base_url
-    return ChatAnthropic(**kwargs)
-
-
-def _build_vertex_client(
-    settings: Settings,
-    spec: "ModelSpec",
-    temperature: Optional[float],
-    has_override: bool,
-) -> BaseLanguageModel:
-    """Create a Vertex AI Gemini chat client instance."""
-
-    try:  # pragma: no cover - optional dependency
-        from langchain.chat_models import ChatVertexAI
-    except ImportError:
-        try:
-            from langchain_google_vertexai import ChatVertexAI  # type: ignore
-        except ImportError as exc:  # pragma: no cover
-            raise RuntimeError(
-                "Google Vertex AI support requires the langchain-google-vertexai package."
-            ) from exc
-
-    vertex_settings = settings.vertex
-    model_name = spec.model_name
-    if not has_override and vertex_settings.model:
-        model_name = vertex_settings.model
-
-    kwargs: Dict[str, Any] = {"model_name": model_name}
-    _maybe_add_temperature(kwargs, temperature)
-    if vertex_settings.project_id:
-        kwargs["project"] = vertex_settings.project_id
-    if vertex_settings.location:
-        kwargs["location"] = vertex_settings.location
-    if vertex_settings.credentials_file:
-        kwargs["credentials_path"] = vertex_settings.credentials_file
-    return ChatVertexAI(**kwargs)
 
 
 __all__ = ["LLMProvider"]


### PR DESCRIPTION
## Summary
- add adapter modules for each chat provider that centralize credentials, retry configuration, and explicit HTTP error handling
- refactor the `LLMProvider` factory to delegate client creation to the new adapters

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d27cd67988833099885e59399472a0