### PR TITLE
Implement prompt catalog API endpoints

### DIFF
--- a/services/prompt_catalog/app.py
+++ b/services/prompt_catalog/app.py
@@ -1,0 +1,104 @@
+"""Prompt Catalog FastAPI application with stubbed prompt data."""
+
+from __future__ import annotations
+
+from fastapi import Depends, FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from shared.models.chat import ChatPrompt, ChatPromptKey
+
+from .repositories import PromptRepository, get_prompt_repository
+
+SERVICE_NAME = "prompt_catalog"
+
+app = FastAPI(title="Prompt Catalog Service")
+
+
+class PromptCollectionResponse(BaseModel):
+    """Response payload containing a collection of prompts."""
+
+    prompts: list[ChatPrompt] = Field(default_factory=list)
+
+
+class PromptResponse(BaseModel):
+    """Response payload containing a single prompt."""
+
+    prompt: ChatPrompt
+
+
+class PromptSearchRequest(BaseModel):
+    """Search criteria for locating prompts."""
+
+    query: str | None = Field(
+        default=None,
+        description="Free-text query to match against prompt metadata and template.",
+    )
+    key: ChatPromptKey | None = Field(
+        default=None, description="Optional canonical prompt key to filter by."
+    )
+    limit: int = Field(
+        default=20,
+        ge=1,
+        le=50,
+        description="Maximum number of prompts to include in the response.",
+    )
+
+
+class PromptSearchResponse(BaseModel):
+    """Response payload containing search results."""
+
+    results: list[ChatPrompt] = Field(default_factory=list)
+
+
+@app.get("/health", tags=["health"])
+async def health() -> dict[str, str]:
+    """Return a simple health payload for orchestration checks."""
+
+    return {"status": "ok", "service": SERVICE_NAME}
+
+
+@app.get("/prompts", response_model=PromptCollectionResponse, tags=["prompts"])
+async def list_prompts(
+    repository: PromptRepository = Depends(get_prompt_repository),
+) -> PromptCollectionResponse:
+    """Return all prompts registered in the catalog."""
+
+    prompts = await repository.list_prompts()
+    return PromptCollectionResponse(prompts=prompts)
+
+
+@app.get("/prompts/{prompt_id}", response_model=PromptResponse, tags=["prompts"])
+async def get_prompt(
+    prompt_id: str,
+    repository: PromptRepository = Depends(get_prompt_repository),
+) -> PromptResponse:
+    """Return a single prompt by ``prompt_id``."""
+
+    prompt = await repository.get_prompt(prompt_id)
+    if prompt is None:
+        raise HTTPException(status_code=404, detail=f"Prompt '{prompt_id}' not found")
+    return PromptResponse(prompt=prompt)
+
+
+@app.post("/prompts/search", response_model=PromptSearchResponse, tags=["prompts"])
+async def search_prompts(
+    payload: PromptSearchRequest,
+    repository: PromptRepository = Depends(get_prompt_repository),
+) -> PromptSearchResponse:
+    """Search prompts using structured criteria."""
+
+    results = await repository.search_prompts(
+        query=payload.query,
+        key=payload.key,
+        limit=payload.limit,
+    )
+    return PromptSearchResponse(results=results)
+
+
+def get_app() -> FastAPI:
+    """Return the FastAPI app instance."""
+
+    return app
+
+
+__all__ = ["app", "get_app"]

--- a/services/prompt_catalog/main.py
+++ b/services/prompt_catalog/main.py
@@ -1,21 +1,8 @@
-"""Prompt Catalog service placeholder application."""
+"""Application entrypoint for the prompt catalog service."""
 
-from fastapi import FastAPI
+from .app import app, get_app
 
-SERVICE_NAME = "prompt_catalog"
-
-app = FastAPI(title="Prompt Catalog Service")
-
-
-@app.get("/health", tags=["health"])
-async def health() -> dict[str, str]:
-    """Return a simple health payload for orchestration checks."""
-    return {"status": "ok", "service": SERVICE_NAME}
-
-
-def get_app() -> FastAPI:
-    """Return the FastAPI app instance."""
-    return app
+__all__ = ["app", "get_app"]
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/services/prompt_catalog/repositories.py
+++ b/services/prompt_catalog/repositories.py
@@ -1,0 +1,143 @@
+"""Repository abstractions for the prompt catalog service."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from shared.models.chat import ChatPrompt, ChatPromptKey
+
+
+class PromptRepository:
+    """In-memory repository for managing :class:`ChatPrompt` definitions."""
+
+    def __init__(self, prompts: Iterable[ChatPrompt] | None = None) -> None:
+        self._prompts: dict[str, ChatPrompt] = {}
+        if prompts is not None:
+            for prompt in prompts:
+                identifier = self._identifier_for_prompt(prompt)
+                self._prompts[identifier] = prompt
+
+    async def list_prompts(self) -> list[ChatPrompt]:
+        """Return all known prompts ordered by insertion."""
+
+        return list(self._prompts.values())
+
+    async def get_prompt(self, prompt_id: str | ChatPromptKey) -> ChatPrompt | None:
+        """Return a prompt matching ``prompt_id`` if one exists."""
+
+        identifier = self._normalize_identifier(str(prompt_id))
+        return self._prompts.get(identifier)
+
+    async def search_prompts(
+        self,
+        *,
+        query: str | None = None,
+        key: ChatPromptKey | None = None,
+        limit: int = 20,
+    ) -> list[ChatPrompt]:
+        """Return prompts filtered by ``query`` and ``key``.
+
+        Parameters
+        ----------
+        query:
+            Optional text that should appear within the prompt metadata or template.
+        key:
+            Optional :class:`ChatPromptKey` to filter for an exact prompt identifier.
+        limit:
+            Maximum number of results to return. A negative value is treated as zero.
+        """
+
+        normalized_key = self._normalize_identifier(str(key)) if key else None
+        normalized_query = query.lower().strip() if query else None
+
+        results: list[ChatPrompt] = []
+        for identifier, prompt in self._prompts.items():
+            if normalized_key and identifier != normalized_key:
+                continue
+
+            if normalized_query and not self._matches_query(prompt, normalized_query):
+                continue
+
+            results.append(prompt)
+            if 0 < limit <= len(results):
+                break
+        return results
+
+    def _matches_query(self, prompt: ChatPrompt, query: str) -> bool:
+        """Return ``True`` if ``query`` appears within prompt metadata."""
+
+        parts: list[str] = []
+        if isinstance(prompt.key, ChatPromptKey):
+            parts.append(prompt.key.value)
+        elif prompt.key:
+            parts.append(str(prompt.key))
+        if prompt.title:
+            parts.append(prompt.title)
+        if prompt.description:
+            parts.append(prompt.description)
+        if prompt.template:
+            parts.append(prompt.template)
+        haystack = " ".join(parts).lower()
+        return query in haystack
+
+    def _identifier_for_prompt(self, prompt: ChatPrompt) -> str:
+        """Return the canonical identifier for ``prompt`` for dictionary storage."""
+
+        if prompt.key:
+            return self._normalize_identifier(str(prompt.key))
+        if prompt.metadata and "id" in prompt.metadata:
+            return self._normalize_identifier(str(prompt.metadata["id"]))
+        if prompt.title:
+            return self._normalize_identifier(prompt.title)
+        raise ValueError("Prompt requires either a key, metadata id, or title for identification")
+
+    @staticmethod
+    def _normalize_identifier(value: str) -> str:
+        """Normalize the identifier for lookups."""
+
+        return value.strip().lower()
+
+
+# TODO: Replace the in-memory repository with a database-backed implementation when
+# persistent storage is available for the prompt catalog service.
+_DEFAULT_PROMPTS: tuple[ChatPrompt, ...] = (
+    ChatPrompt(
+        key=ChatPromptKey.PATIENT_CONTEXT,
+        title="Patient Context Overview",
+        description="Summarize clinical background and social determinants for the visit.",
+        template=(
+            "You are drafting a concise patient context summary using the provided "
+            "clinical background: {patient_background}. Highlight key risk factors, "
+            "recent events, and any notable social determinants of health."
+        ),
+        input_variables=["patient_background"],
+    ),
+    ChatPrompt(
+        key=ChatPromptKey.CLINICAL_PLAN,
+        title="Clinical Plan Outline",
+        description="Construct a draft plan that covers assessment, diagnostics, and treatment.",
+        template=(
+            "Using the encounter data in {encounter_overview}, craft a step-by-step clinical "
+            "plan addressing differential diagnoses, recommended studies, and follow-up."
+        ),
+        input_variables=["encounter_overview"],
+    ),
+    ChatPrompt(
+        key=ChatPromptKey.FOLLOW_UP_QUESTIONS,
+        title="Follow-up Question Suggestions",
+        description="Suggest clarifying questions to ask the patient during follow-up.",
+        template=(
+            "Given the patient summary {patient_summary}, generate targeted follow-up "
+            "questions to explore unresolved issues and safety concerns."
+        ),
+        input_variables=["patient_summary"],
+    ),
+)
+
+_PROMPT_REPOSITORY = PromptRepository(_DEFAULT_PROMPTS)
+
+
+def get_prompt_repository() -> PromptRepository:
+    """Dependency provider returning the application's prompt repository."""
+
+    return _PROMPT_REPOSITORY


### PR DESCRIPTION
## Summary
- implement a FastAPI application module for the prompt catalog that exposes list, detail, and search routes using shared chat models
- add an in-memory prompt repository with sample data and a TODO marker for future database-backed integration
- update the prompt catalog service entrypoint to re-export the new application module

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d281d0495883309cb158f609642101