### PR TITLE
Add patient context service endpoints with EMR repository

### DIFF
--- a/repositories/__init__.py
+++ b/repositories/__init__.py
@@ -1,0 +1,5 @@
+"""Data access repositories supporting ChatEHR services."""
+
+from .emr import EMRRepository
+
+__all__ = ["EMRRepository"]

--- a/repositories/emr.py
+++ b/repositories/emr.py
@@ -1,0 +1,237 @@
+"""Repository abstractions for retrieving patient data from an EMR system."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+# ---------------------------------------------------------------------------
+# Fixture data used while the service is under active development.
+# TODO: Replace these fixtures with real EMR integrations.
+# ---------------------------------------------------------------------------
+
+_SAMPLE_PATIENT_RECORD: dict[str, Any] = {
+    "demographics": {
+        "patientId": "123456",
+        "mrn": "MRN0012345",
+        "firstName": "Ava",
+        "lastName": "Thompson",
+        "fullName": "Ava M. Thompson",
+        "dateOfBirth": "1982-09-14",
+        "age": 41,
+        "gender": "Female",
+        "language": "English",
+        "address": "123 Main St, Springfield, IL",
+        "phone": "555-123-4567",
+        "email": "ava.thompson@example.com",
+        "preferredContactMethod": "phone",
+    },
+    "encounters": [
+        {
+            "encounterId": "enc-1001",
+            "type": "outpatient",
+            "reason": "Hypertension follow up",
+            "start": "2024-03-01T09:00:00+00:00",
+            "end": "2024-03-01T09:30:00+00:00",
+            "location": "Springfield Clinic",
+            "provider": "Dr. Samuel Carter",
+            "status": "completed",
+            "notes": "Stable vitals, medication adherence good.",
+        }
+    ],
+    "medications": [
+        {
+            "name": "Lisinopril",
+            "dose": "10 mg",
+            "route": "PO",
+            "frequency": "daily",
+            "startDate": "2023-11-15",
+            "indication": "Hypertension",
+            "status": "active",
+        },
+        {
+            "name": "Atorvastatin",
+            "dose": "20 mg",
+            "route": "PO",
+            "frequency": "daily",
+            "startDate": "2022-08-05",
+            "indication": "Hyperlipidemia",
+            "status": "active",
+        },
+    ],
+    "allergies": [
+        {
+            "substance": "Penicillin",
+            "reaction": "Rash",
+            "severity": "mild",
+            "status": "active",
+            "notedDate": "2001-04-12",
+        }
+    ],
+    "problems": [
+        {
+            "name": "Essential hypertension",
+            "status": "active",
+            "onset": "2019-06-10",
+            "notes": "Controlled with medication.",
+        },
+        {
+            "name": "Hyperlipidemia",
+            "status": "active",
+            "onset": "2022-07-22",
+        },
+    ],
+    "vitalSigns": [
+        {
+            "type": "blood_pressure",
+            "value": "128/82",
+            "unit": "mmHg",
+            "takenAt": "2024-03-01T09:10:00+00:00",
+        },
+        {
+            "type": "heart_rate",
+            "value": "72",
+            "unit": "bpm",
+            "takenAt": "2024-03-01T09:10:00+00:00",
+        },
+    ],
+    "labResults": [
+        {
+            "testCode": "BMP",
+            "testName": "Basic Metabolic Panel",
+            "value": "Within normal limits",
+            "status": "final",
+            "collectedAt": "2024-02-20T07:20:00+00:00",
+            "resultedAt": "2024-02-20T15:45:00+00:00",
+        },
+        {
+            "testCode": "LIPID",
+            "testName": "Lipid Panel",
+            "value": "LDL 102 mg/dL",
+            "status": "final",
+            "collectedAt": "2024-02-20T07:20:00+00:00",
+            "resultedAt": "2024-02-20T15:45:00+00:00",
+        },
+    ],
+    "clinicalNotes": [
+        {
+            "noteId": "note-123",
+            "title": "Outpatient visit note",
+            "noteType": "Progress Note",
+            "createdAt": "2024-03-01T09:35:00+00:00",
+            "author": "Dr. Samuel Carter",
+            "content": "Patient reports improved diet and adherence to medication.",
+        }
+    ],
+    "careTeam": [
+        {
+            "name": "Samuel Carter, MD",
+            "role": "Primary Care Physician",
+            "organization": "Springfield Clinic",
+        },
+        {
+            "name": "Angela Patel, RN",
+            "role": "Nurse Care Manager",
+            "organization": "Springfield Clinic",
+        },
+    ],
+    "socialHistory": [
+        {
+            "category": "Tobacco",
+            "description": "Never smoker",
+            "recordedAt": "2020-05-10",
+        },
+        {
+            "category": "Alcohol",
+            "description": "Social drinking, 1-2 glasses of wine/week",
+            "recordedAt": "2023-01-19",
+        },
+    ],
+    "familyHistory": [
+        {
+            "relationship": "Father",
+            "condition": "Coronary artery disease",
+            "status": "deceased",
+        },
+        {
+            "relationship": "Mother",
+            "condition": "Type 2 diabetes",
+            "status": "living",
+        },
+    ],
+}
+
+_SAMPLE_PATIENT_CONTEXT: dict[str, Any] = deepcopy(_SAMPLE_PATIENT_RECORD)
+_SAMPLE_PATIENT_CONTEXT.update(
+    {
+        "chiefComplaint": "Routine hypertension follow up",
+        "historyOfPresentIllness": (
+            "Ava Thompson is a 41-year-old female presenting for hypertension follow "
+            "up. Reports improved energy and compliance with medications."
+        ),
+        "assessment": (
+            "Essential hypertension well controlled on current regimen. "
+            "Hyperlipidemia remains borderline."
+        ),
+        "plan": (
+            "Continue lisinopril and atorvastatin. Encourage DASH diet, maintain "
+            "exercise routine, and repeat labs in three months."
+        ),
+        "goals": [
+            {
+                "title": "Maintain blood pressure below 130/80 mmHg",
+                "description": "Continue daily medications and weekly home blood pressure logs.",
+                "status": "active",
+            },
+            {
+                "title": "Increase physical activity",
+                "description": "Achieve 150 minutes of moderate exercise each week.",
+                "status": "active",
+            },
+        ],
+        "followUpActions": [
+            "Schedule fasting labs in three months",
+            "Upload home blood pressure log via patient portal",
+        ],
+        "additionalNotes": [
+            {
+                "noteId": "note-124",
+                "title": "Nurse outreach call",
+                "noteType": "Telephone Encounter",
+                "createdAt": "2024-03-15T14:05:00+00:00",
+                "author": "Angela Patel, RN",
+                "content": "Patient confirms adherence to medications and requests lab reminders.",
+            }
+        ],
+    }
+)
+
+_PATIENT_FIXTURES: dict[str, dict[str, dict[str, Any]]] = {
+    "123456": {
+        "record": _SAMPLE_PATIENT_RECORD,
+        "context": _SAMPLE_PATIENT_CONTEXT,
+    }
+}
+
+
+class EMRRepository:
+    """Repository for retrieving patient data from an electronic medical record."""
+
+    async def fetch_patient_record(self, patient_id: str) -> Mapping[str, Any] | None:
+        """Return a longitudinal patient record for ``patient_id`` if known."""
+
+        patient = _PATIENT_FIXTURES.get(patient_id)
+        if not patient:
+            return None
+        return deepcopy(patient["record"])
+
+    async def fetch_patient_context(self, patient_id: str) -> Mapping[str, Any] | None:
+        """Return a curated patient context payload for ``patient_id`` if known."""
+
+        patient = _PATIENT_FIXTURES.get(patient_id)
+        if not patient:
+            return None
+        return deepcopy(patient["context"])
+
+
+__all__ = ["EMRRepository"]

--- a/services/patient_context/app.py
+++ b/services/patient_context/app.py
@@ -1,0 +1,81 @@
+"""FastAPI application exposing patient context capabilities."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, status
+
+from repositories.emr import EMRRepository
+from services.patient_context.mappers import map_patient_context, map_patient_record
+from shared.models import EHRPatientContext, PatientRecord
+
+SERVICE_NAME = "patient_context"
+
+app = FastAPI(title="Patient Context Service")
+router = APIRouter(prefix="/patients", tags=["patients"])
+_repository = EMRRepository()
+
+
+def get_repository() -> EMRRepository:
+    """Return the shared :class:`EMRRepository` instance."""
+
+    return _repository
+
+
+@app.get("/health", tags=["health"])
+async def health() -> dict[str, str]:
+    """Return a simple health payload for orchestration checks."""
+
+    return {"status": "ok", "service": SERVICE_NAME}
+
+
+@router.get("/{patient_id}", response_model=PatientRecord, status_code=status.HTTP_200_OK)
+async def read_patient_record(
+    patient_id: str, repo: EMRRepository = Depends(get_repository)
+) -> PatientRecord:
+    """Return the normalized patient record for ``patient_id``."""
+
+    raw_record = await repo.fetch_patient_record(patient_id)
+    if raw_record is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Patient '{patient_id}' was not found.",
+        )
+    try:
+        return map_patient_record(raw_record)
+    except ValueError as exc:  # pragma: no cover - defensive branch
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Unable to normalize patient record: {exc}",
+        ) from exc
+
+
+@router.get(
+    "/context",
+    response_model=EHRPatientContext,
+    status_code=status.HTTP_200_OK,
+)
+async def read_patient_context(
+    patient_id: str = Query(..., description="Unique identifier for the patient"),
+    repo: EMRRepository = Depends(get_repository),
+) -> EHRPatientContext:
+    """Return the chat-oriented patient context for ``patient_id``."""
+
+    raw_context = await repo.fetch_patient_context(patient_id)
+    if raw_context is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Patient '{patient_id}' was not found.",
+        )
+    try:
+        return map_patient_context(raw_context)
+    except ValueError as exc:  # pragma: no cover - defensive branch
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Unable to normalize patient context: {exc}",
+        ) from exc
+
+
+app.include_router(router)
+
+
+__all__ = ["app", "get_repository", "health"]

--- a/services/patient_context/main.py
+++ b/services/patient_context/main.py
@@ -1,20 +1,17 @@
-"""Patient Context service placeholder application."""
+"""Entrypoint module for running the Patient Context FastAPI service."""
+
+from __future__ import annotations
 
 from fastapi import FastAPI
 
-SERVICE_NAME = "patient_context"
+from .app import app
 
-app = FastAPI(title="Patient Context Service")
-
-
-@app.get("/health", tags=["health"])
-async def health() -> dict[str, str]:
-    """Return a simple health payload for orchestration checks."""
-    return {"status": "ok", "service": SERVICE_NAME}
+__all__ = ["app", "get_app"]
 
 
 def get_app() -> FastAPI:
-    """Return the FastAPI app instance."""
+    """Return the configured FastAPI application."""
+
     return app
 
 

--- a/services/patient_context/mappers.py
+++ b/services/patient_context/mappers.py
@@ -1,0 +1,59 @@
+"""Utilities for normalizing raw EMR payloads into service models."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from shared.models import EHRPatientContext, PatientRecord
+
+_CAMEL_BOUNDARY_1 = re.compile(r"(.)([A-Z][a-z]+)")
+_CAMEL_BOUNDARY_2 = re.compile(r"([a-z0-9])([A-Z])")
+
+
+def _normalize_key(key: str) -> str:
+    """Return a ``snake_case`` representation of ``key``."""
+
+    cleaned = key.strip()
+    if not cleaned:
+        return cleaned
+    cleaned = cleaned.replace("-", "_").replace("/", "_").replace(" ", "_")
+    cleaned = _CAMEL_BOUNDARY_1.sub(r"\1_\2", cleaned)
+    cleaned = _CAMEL_BOUNDARY_2.sub(r"\1_\2", cleaned)
+    cleaned = re.sub(r"__+", "_", cleaned)
+    return cleaned.lower()
+
+
+def _normalize_structure(value: Any) -> Any:
+    """Recursively convert mapping keys to ``snake_case``."""
+
+    if isinstance(value, Mapping):
+        return {
+            _normalize_key(str(key)): _normalize_structure(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_normalize_structure(item) for item in value]
+    return value
+
+
+def map_patient_record(payload: Mapping[str, Any] | None) -> PatientRecord:
+    """Convert a raw patient record payload into a :class:`PatientRecord`."""
+
+    if payload is None:
+        raise ValueError("Patient record payload is empty")
+    normalized = _normalize_structure(payload)
+    return PatientRecord.model_validate(normalized)
+
+
+def map_patient_context(payload: Mapping[str, Any] | None) -> EHRPatientContext:
+    """Convert a raw patient context payload into :class:`EHRPatientContext`."""
+
+    if payload is None:
+        raise ValueError("Patient context payload is empty")
+    normalized = _normalize_structure(payload)
+    return EHRPatientContext.model_validate(normalized)
+
+
+__all__ = ["map_patient_context", "map_patient_record"]


### PR DESCRIPTION
## Summary
- add a FastAPI application module for patient record and context endpoints
- implement an EMR repository stub and mapping utilities to normalize payloads
- wire main entrypoint to the new application module

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d28696a9d083308b43a9a336b3ec3a