### PR TITLE
Add observability utilities and request tracing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ dependencies = [
     "pydantic-settings>=2.1,<3",
     "python-dotenv>=1.0,<2",
     "openai>=1.14,<2",
-    "anthropic>=0.21,<0.22"
+    "anthropic>=0.21,<0.22",
+    "loguru>=0.7,<0.8",
+    "structlog>=24.1,<25"
 ]
 
 [project.urls]

--- a/services/patient_context/app.py
+++ b/services/patient_context/app.py
@@ -7,12 +7,22 @@ from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, status
 from repositories.emr import EMRRepository
 from services.patient_context.mappers import map_patient_context, map_patient_record
 from shared.models import EHRPatientContext, PatientRecord
+from shared.observability.logger import configure_logging
+from shared.observability.middleware import (
+    CorrelationIdMiddleware,
+    RequestTimingMiddleware,
+)
 
 SERVICE_NAME = "patient_context"
+
+configure_logging(service_name=SERVICE_NAME)
 
 app = FastAPI(title="Patient Context Service")
 router = APIRouter(prefix="/patients", tags=["patients"])
 _repository = EMRRepository()
+
+app.add_middleware(RequestTimingMiddleware)
+app.add_middleware(CorrelationIdMiddleware)
 
 
 def get_repository() -> EMRRepository:

--- a/services/prompt_catalog/app.py
+++ b/services/prompt_catalog/app.py
@@ -6,12 +6,21 @@ from fastapi import Depends, FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 from shared.models.chat import ChatPrompt, ChatPromptKey
+from shared.observability.logger import configure_logging
+from shared.observability.middleware import (
+    CorrelationIdMiddleware,
+    RequestTimingMiddleware,
+)
 
 from .repositories import PromptRepository, get_prompt_repository
 
 SERVICE_NAME = "prompt_catalog"
 
+configure_logging(service_name=SERVICE_NAME)
+
 app = FastAPI(title="Prompt Catalog Service")
+app.add_middleware(RequestTimingMiddleware)
+app.add_middleware(CorrelationIdMiddleware)
 
 
 class PromptCollectionResponse(BaseModel):

--- a/shared/observability/__init__.py
+++ b/shared/observability/__init__.py
@@ -1,0 +1,32 @@
+"""Observability utilities shared across ChatEHR services."""
+
+from .logger import (
+    configure_logging,
+    generate_request_id,
+    get_logger,
+    get_request_id,
+    request_context,
+)
+from .middleware import CorrelationIdMiddleware, RequestTimingMiddleware
+from .audit import (
+    ChatAudit,
+    AuditRepository,
+    StdoutAuditRepository,
+    get_audit_repository,
+    record_chat_audit,
+)
+
+__all__ = [
+    "AuditRepository",
+    "ChatAudit",
+    "CorrelationIdMiddleware",
+    "RequestTimingMiddleware",
+    "StdoutAuditRepository",
+    "configure_logging",
+    "generate_request_id",
+    "get_audit_repository",
+    "get_logger",
+    "get_request_id",
+    "record_chat_audit",
+    "request_context",
+]

--- a/shared/observability/audit.py
+++ b/shared/observability/audit.py
@@ -1,0 +1,114 @@
+"""Audit helpers for recording chat-related events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+import structlog
+
+from .logger import get_logger, get_request_id
+
+__all__ = [
+    "AuditRepository",
+    "ChatAudit",
+    "StdoutAuditRepository",
+    "get_audit_repository",
+    "record_chat_audit",
+]
+
+
+@dataclass(slots=True)
+class ChatAudit:
+    """Structured payload describing an auditable chat event."""
+
+    event: str
+    actor: str | None = None
+    subject: str | None = None
+    request_id: str | None = None
+    session_id: str | None = None
+    service: str | None = None
+    success: bool | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation of the audit entry."""
+
+        payload = {
+            "event": self.event,
+            "actor": self.actor,
+            "subject": self.subject,
+            "requestId": self.request_id,
+            "sessionId": self.session_id,
+            "service": self.service,
+            "success": self.success,
+            "metadata": dict(self.metadata),
+            "createdAt": self.created_at.isoformat(),
+        }
+        return payload
+
+
+class AuditRepository(Protocol):
+    """Abstract repository contract for persisting chat audit events."""
+
+    async def persist(self, audit: ChatAudit) -> None:  # pragma: no cover - interface definition
+        """Persist ``audit`` to the underlying storage backend."""
+
+
+class StdoutAuditRepository:
+    """Persist audit entries to the configured logger."""
+
+    def __init__(self) -> None:
+        self._logger = get_logger("audit")
+
+    async def persist(self, audit: ChatAudit) -> None:
+        payload = audit.to_dict()
+        self._logger.info("chat_audit", **payload)
+
+
+_DEFAULT_REPOSITORY: AuditRepository | None = None
+
+
+def get_audit_repository() -> AuditRepository:
+    """Return the globally configured audit repository."""
+
+    global _DEFAULT_REPOSITORY
+    if _DEFAULT_REPOSITORY is None:
+        _DEFAULT_REPOSITORY = StdoutAuditRepository()
+    return _DEFAULT_REPOSITORY
+
+
+async def record_chat_audit(
+    event: str,
+    *,
+    actor: str | None = None,
+    subject: str | None = None,
+    session_id: str | None = None,
+    success: bool | None = None,
+    metadata: dict[str, Any] | None = None,
+    repository: AuditRepository | None = None,
+    request_id: str | None = None,
+    service: str | None = None,
+) -> ChatAudit:
+    """Capture an audit event and persist it using the configured repository."""
+
+    repo = repository or get_audit_repository()
+    resolved_request_id = request_id or get_request_id()
+    context = structlog.contextvars.get_contextvars()
+    resolved_service = service or context.get("service")
+
+    audit_entry = ChatAudit(
+        event=event,
+        actor=actor,
+        subject=subject,
+        request_id=resolved_request_id,
+        session_id=session_id,
+        service=resolved_service,
+        success=success,
+        metadata=dict(metadata or {}),
+    )
+
+    await repo.persist(audit_entry)
+    return audit_entry

--- a/shared/observability/logger.py
+++ b/shared/observability/logger.py
@@ -1,0 +1,185 @@
+"""Logging helpers integrating structlog and loguru with request context."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Callable, Iterator
+
+import structlog
+from loguru import logger as loguru_logger
+
+__all__ = [
+    "configure_logging",
+    "generate_request_id",
+    "get_logger",
+    "get_request_id",
+    "request_context",
+]
+
+_REQUEST_ID: ContextVar[str | None] = ContextVar("request_id", default=None)
+_CONFIGURED: bool = False
+_SERVICE_NAME: str | None = None
+
+
+def _format_record(record: dict[str, Any]) -> str:
+    """Return the default loguru format string for structured log output."""
+
+    timestamp = record["time"].isoformat()
+    level = record["level"].name
+    extra = record.get("extra") or {}
+    service = extra.get("service", "-")
+    request_id = extra.get("request_id") or extra.get("correlation_id") or "-"
+    message = record.get("message", "")
+    return f"{timestamp} | {level:<8} | {service} | {request_id} | {message}\n"
+
+
+def _coerce_level(level: str | int) -> tuple[int, str]:
+    """Normalize ``level`` to logging and loguru compatible representations."""
+
+    if isinstance(level, int):
+        numeric = level
+    else:
+        normalized = logging.getLevelName(level.upper())
+        if not isinstance(normalized, int):  # pragma: no cover - defensive branch
+            raise ValueError(f"Unknown log level: {level}")
+        numeric = normalized
+    name = logging.getLevelName(numeric)
+    if not isinstance(name, str):  # pragma: no cover - defensive branch
+        name = "INFO"
+    return numeric, name
+
+
+def get_request_id() -> str | None:
+    """Return the request identifier bound to the current context, if any."""
+
+    return _REQUEST_ID.get()
+
+
+def generate_request_id() -> str:
+    """Return a new opaque request identifier."""
+
+    return uuid.uuid4().hex
+
+
+class LoguruInterceptHandler(logging.Handler):
+    """Route standard logging records through Loguru while preserving context."""
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - thin wrapper
+        try:
+            level = loguru_logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+
+        frame, depth = logging.currentframe(), 2
+        while frame and frame.f_code.co_filename == logging.__file__:
+            frame = frame.f_back
+            depth += 1
+
+        bound = loguru_logger.bind(logger=record.name)
+        request_id = get_request_id()
+        if request_id:
+            bound = bound.bind(request_id=request_id, correlation_id=request_id)
+
+        bound.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
+
+
+def _configure_structlog() -> None:
+    """Configure structlog to emit JSON payloads with context variables."""
+
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.JSONRenderer(),
+        ],
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+
+def configure_logging(*, service_name: str | None = None, level: str | int = "INFO") -> None:
+    """Configure loguru/structlog integration for the current process.
+
+    The configuration step is idempotent and safe to call from multiple modules.
+    ``service_name`` will be attached to all structured log entries.
+    """
+
+    global _CONFIGURED, _SERVICE_NAME
+
+    numeric_level, level_name = _coerce_level(level)
+
+    if not _CONFIGURED:
+        loguru_logger.remove()
+        loguru_logger.add(
+            sys.stdout,
+            level=level_name,
+            enqueue=True,
+            backtrace=False,
+            diagnose=False,
+            format=_format_record,
+        )
+
+        logging.basicConfig(
+            handlers=[LoguruInterceptHandler()],
+            level=numeric_level,
+            force=True,
+        )
+        logging.captureWarnings(True)
+
+        _configure_structlog()
+        _CONFIGURED = True
+
+    if service_name:
+        _SERVICE_NAME = service_name
+        loguru_logger.configure(extra={"service": service_name})
+        structlog.contextvars.bind_contextvars(service=service_name)
+
+
+def get_logger(name: str | None = None) -> structlog.stdlib.BoundLogger:
+    """Return a structlog bound logger with the given ``name``."""
+
+    if name is None:
+        return structlog.get_logger()
+    return structlog.get_logger(name)
+
+
+@contextmanager
+def request_context(
+    request_id: str | None = None,
+    *,
+    bind: Callable[..., None] | None = None,
+    **extra: Any,
+) -> Iterator[str]:
+    """Bind ``request_id`` and extra context for the lifetime of the block."""
+
+    if "request_id" in extra:  # pragma: no cover - guard against conflicting kwargs
+        extra.pop("request_id")
+
+    rid = request_id or generate_request_id()
+    token = _REQUEST_ID.set(rid)
+    context_values = dict(extra)
+    if _SERVICE_NAME and "service" not in context_values:
+        context_values["service"] = _SERVICE_NAME
+    correlation = context_values.setdefault("correlation_id", rid)
+
+    structlog.contextvars.bind_contextvars(request_id=rid, **context_values)
+
+    bound_keys = list(dict.fromkeys(["request_id", *context_values.keys()]))
+
+    with loguru_logger.contextualize(request_id=rid, correlation_id=correlation, **extra):
+        if bind is not None:
+            bind()
+        try:
+            yield rid
+        finally:
+            structlog.contextvars.unbind_contextvars(*bound_keys)
+            _REQUEST_ID.reset(token)

--- a/shared/observability/middleware.py
+++ b/shared/observability/middleware.py
@@ -1,0 +1,125 @@
+"""Reusable FastAPI middleware for observability instrumentation."""
+
+from __future__ import annotations
+
+import time
+from typing import Awaitable, Callable, Iterable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+from .logger import generate_request_id, get_logger, request_context
+
+__all__ = ["CorrelationIdMiddleware", "RequestTimingMiddleware"]
+
+
+class CorrelationIdMiddleware(BaseHTTPMiddleware):
+    """Populate a request identifier and propagate it through the response."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        header_name: str = "X-Request-ID",
+        correlation_header: str = "X-Correlation-ID",
+        additional_headers: Iterable[str] | None = None,
+    ) -> None:
+        super().__init__(app)
+        self.header_name = header_name
+        self.correlation_header = correlation_header or header_name
+        candidates = [self.header_name, self.correlation_header, "X-Request-ID", "X-Correlation-ID"]
+        if additional_headers:
+            candidates.extend(additional_headers)
+        # Remove duplicates while preserving order.
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for name in candidates:
+            normalized = name.strip()
+            if not normalized:
+                continue
+            key = normalized.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            ordered.append(normalized)
+        self._candidate_headers = ordered
+
+    def _resolve_request_id(self, request: Request) -> str:
+        for header in self._candidate_headers:
+            value = request.headers.get(header)
+            if value:
+                candidate = value.strip()
+                if candidate:
+                    return candidate[:128]
+        return generate_request_id()
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        request_id = self._resolve_request_id(request)
+        request.state.request_id = request_id
+        request.state.correlation_id = request_id
+        request.scope["request_id"] = request_id
+        request.scope["correlation_id"] = request_id
+
+        with request_context(request_id=request_id):
+            response = await call_next(request)
+
+        response.headers.setdefault(self.header_name, request_id)
+        response.headers.setdefault(self.correlation_header, request_id)
+        return response
+
+
+class RequestTimingMiddleware(BaseHTTPMiddleware):
+    """Measure request latency and emit structured log entries."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        header_name: str = "X-Response-Time",
+    ) -> None:
+        super().__init__(app)
+        self._header_name = header_name
+        self._logger = get_logger("http")
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        start = time.perf_counter()
+        client = request.client.host if request.client else None
+        user_agent = request.headers.get("user-agent")
+
+        try:
+            response = await call_next(request)
+        except Exception:
+            duration_ms = (time.perf_counter() - start) * 1000.0
+            self._logger.bind(
+                method=request.method,
+                path=request.url.path,
+                duration_ms=duration_ms,
+                client=client,
+                user_agent=user_agent,
+            ).exception("http_request_failed")
+            raise
+
+        duration_ms = (time.perf_counter() - start) * 1000.0
+        if self._header_name:
+            response.headers[self._header_name] = f"{duration_ms / 1000.0:.6f}s"
+
+        self._logger.bind(
+            method=request.method,
+            path=request.url.path,
+            status_code=response.status_code,
+            duration_ms=duration_ms,
+            client=client,
+            user_agent=user_agent,
+        ).info("http_request_completed")
+
+        return response


### PR DESCRIPTION
## Summary
- configure a shared structlog/loguru logger that propagates request identifiers
- add chat audit helpers with a stdout-backed repository
- instrument each FastAPI service with correlation ID and timing middleware

## Testing
- python -m compileall shared services

------
https://chatgpt.com/codex/tasks/task_e_68d29be02e548330ae97a6ba80b4cace