### PR TITLE
Add docker tooling for local service orchestration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,36 @@
+# Copy this file to `.env` before running docker compose commands.
+
+# Docker build configuration
+BASE_IMAGE=ai-chat-ehr-base:latest
+
+# Chain executor outbound HTTP configuration
+CHAIN_EXECUTOR_PROMPT_CATALOG_URL=http://prompt-catalog:8001
+CHAIN_EXECUTOR_PATIENT_CONTEXT_URL=http://patient-context:8002
+CHAIN_EXECUTOR_HTTP_TIMEOUT=10
+
+# Default model selection
+DEFAULT_MODEL__PROVIDER=openai
+DEFAULT_MODEL__NAME=gpt-3.5-turbo
+DEFAULT_MODEL__TEMPERATURE=0.7
+
+# Provider credentials (replace with real values as needed)
+OPENAI_API_KEY=your-openai-api-key
+OPENAI_ORGANIZATION=
+OPENAI_PROJECT=
+OPENAI_BASE_URL=
+
+AZURE_API_KEY=
+AZURE_ENDPOINT=
+AZURE_DEPLOYMENT_NAME=
+AZURE_API_VERSION=
+
+ANTHROPIC_API_KEY=
+ANTHROPIC_BASE_URL=
+
+VERTEX_PROJECT_ID=
+VERTEX_LOCATION=
+VERTEX_CREDENTIALS_FILE=
+VERTEX_MODEL=
+
+# Example data store configuration
+REDIS_URL=redis://redis:6379/0

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1.5
+
+ARG PYTHON_VERSION=3.11-slim
+FROM python:${PYTHON_VERSION} AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONPATH=/app
+
+WORKDIR /app
+
+# Install build tooling required for optional native dependencies
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        build-essential \
+        libffi-dev \
+        python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Upgrade packaging tooling prior to dependency installation
+RUN pip install --upgrade pip setuptools wheel
+
+# Install the shared Python dependencies declared by the project
+RUN pip install --no-cache-dir \
+        "fastapi>=0.110,<1" \
+        "uvicorn[standard]>=0.29,<0.30" \
+        "langchain>=0.1,<0.2" \
+        "httpx>=0.27,<0.28" \
+        "pydantic-settings>=2.1,<3" \
+        "python-dotenv>=1.0,<2" \
+        "openai>=1.14,<2" \
+        "anthropic>=0.21,<0.22" \
+        "loguru>=0.7,<0.8" \
+        "structlog>=24.1,<25" \
+        "tenacity>=8.2,<9"
+

--- a/README.md
+++ b/README.md
@@ -26,3 +26,38 @@ warning, emits an informational event, and falls back to a buffered response. In
 this mode the `chunk` event contains the entire response payload, and the final
 `response` event reports `"streaming": false` so clients can adjust their user
 experience accordingly.
+
+## Running the services with Docker Compose
+
+The repository ships with container definitions for each FastAPI service plus a
+shared Python base image. To start the stack locally:
+
+1. Build the common base image:
+
+   ```bash
+   docker build -f Dockerfile.base -t ai-chat-ehr-base .
+   ```
+
+2. Bootstrap your environment configuration:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   Update `.env` with any provider credentials or overrides that you need for
+   experimentation.
+
+3. Launch the services and supporting Redis instance:
+
+   ```bash
+   docker compose up --build
+   ```
+
+   The compose file exposes the services on the following ports:
+
+   * Prompt catalog – <http://localhost:8001>
+   * Patient context – <http://localhost:8002>
+   * Chain executor – <http://localhost:8003>
+   * Redis mock datastore – `localhost:6379`
+
+   Use `docker compose down` to stop the stack once you finish testing.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,59 @@
+version: "3.9"
+
+services:
+  prompt-catalog:
+    image: ai-chat-ehr-prompt-catalog:latest
+    build:
+      context: .
+      dockerfile: services/prompt_catalog/Dockerfile
+      args:
+        BASE_IMAGE: ${BASE_IMAGE:-ai-chat-ehr-base:latest}
+    env_file:
+      - .env
+    ports:
+      - "8001:8001"
+    depends_on:
+      - redis
+
+  patient-context:
+    image: ai-chat-ehr-patient-context:latest
+    build:
+      context: .
+      dockerfile: services/patient_context/Dockerfile
+      args:
+        BASE_IMAGE: ${BASE_IMAGE:-ai-chat-ehr-base:latest}
+    env_file:
+      - .env
+    ports:
+      - "8002:8002"
+    depends_on:
+      - redis
+
+  chain-executor:
+    image: ai-chat-ehr-chain-executor:latest
+    build:
+      context: .
+      dockerfile: services/chain_executor/Dockerfile
+      args:
+        BASE_IMAGE: ${BASE_IMAGE:-ai-chat-ehr-base:latest}
+    env_file:
+      - .env
+    ports:
+      - "8003:8003"
+    depends_on:
+      prompt-catalog:
+        condition: service_started
+      patient-context:
+        condition: service_started
+      redis:
+        condition: service_started
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5

--- a/services/chain_executor/Dockerfile
+++ b/services/chain_executor/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.5
+
+ARG BASE_IMAGE=ai-chat-ehr-base:latest
+FROM ${BASE_IMAGE} AS runtime
+
+WORKDIR /app
+
+COPY shared ./shared
+COPY services/chain_executor ./services/chain_executor
+
+EXPOSE 8003
+
+CMD ["uvicorn", "services.chain_executor.main:app", "--host", "0.0.0.0", "--port", "8003"]

--- a/services/patient_context/Dockerfile
+++ b/services/patient_context/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1.5
+
+ARG BASE_IMAGE=ai-chat-ehr-base:latest
+FROM ${BASE_IMAGE} AS runtime
+
+WORKDIR /app
+
+COPY shared ./shared
+COPY repositories ./repositories
+COPY services/patient_context ./services/patient_context
+
+EXPOSE 8002
+
+CMD ["uvicorn", "services.patient_context.main:app", "--host", "0.0.0.0", "--port", "8002"]

--- a/services/prompt_catalog/Dockerfile
+++ b/services/prompt_catalog/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1.5
+
+ARG BASE_IMAGE=ai-chat-ehr-base:latest
+FROM ${BASE_IMAGE} AS runtime
+
+WORKDIR /app
+
+COPY shared ./shared
+COPY repositories ./repositories
+COPY services/prompt_catalog ./services/prompt_catalog
+
+EXPOSE 8001
+
+CMD ["uvicorn", "services.prompt_catalog.main:app", "--host", "0.0.0.0", "--port", "8001"]


### PR DESCRIPTION
## Summary
- add a reusable Python base image and per-service Dockerfiles
- define a docker compose stack with the three services and Redis
- document environment setup with a sample .env file and README instructions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2a71ee4d88330b03eba67517e9cde