### PR TITLE
Add CI workflow for linting and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  lint-and-test:
+    name: Lint and Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install . ruff mypy pytest
+
+      - name: Check formatting
+        run: ruff format --check .
+
+      - name: Lint with Ruff
+        run: ruff check .
+
+      - name: Type-check with mypy
+        run: mypy .
+
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow triggered on pull requests
- run ruff (including format checks), mypy, and pytest against Python 3.10 and 3.11
- cache pip dependencies for faster CI runs

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d332b9d39483309a3846931c7042b9