### PR TITLE
Document service docs and publish OpenAPI specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,117 @@
 # ai-chat-ehr
+
 Proving Grounds for ChatEHR
 
-## Streaming chain execution
+## Overview
 
-The chain executor service exposes a streaming endpoint at
-`POST /chains/execute/stream`. The endpoint emits server-sent events (SSE) so
-clients can render language model output as it is generated. Each event is a JSON
-payload delivered in the `data:` field and includes a `type` attribute. The most
-common event types are:
+`ai-chat-ehr` is a collection of FastAPI services that orchestrate language-model
+powered clinical workflows. The stack bundles separate services for managing
+prompt templates, retrieving patient context, and executing prompt chains against
+configurable LLM providers. Each service can be run independently for focused
+experimentation or together via Docker Compose for an end-to-end chat
+experience.
 
-* `metadata` – initial service metadata including provider, model, and whether
-  streaming is expected for the selected model.
-* `step` – emitted after non-streaming steps in the chain complete to expose the
-  intermediate output keyed by `outputKey`.
-* `chunk` – incremental text from the final LLM step. When a provider cannot
-  stream tokens the event includes `"buffered": true` and carries the complete
-  response.
-* `response` – a serialized `ChainExecutionResponse` matching the buffered
-  endpoint plus a `streaming` flag indicating whether streaming succeeded.
-* `error` – final event describing why execution failed when an exception
-  occurs.
+## Service overview
 
-When the chosen provider or model does not support streaming, the service logs a
-warning, emits an informational event, and falls back to a buffered response. In
-this mode the `chunk` event contains the entire response payload, and the final
-`response` event reports `"streaming": false` so clients can adjust their user
-experience accordingly.
+| Service | Purpose | Default port | Swagger UI | OpenAPI spec |
+| --- | --- | --- | --- | --- |
+| API gateway | Reverse proxy that fronts the prompt, patient, and chain services with consistent observability and health checks. | 8000 | <http://localhost:8000/docs> | [`docs/openapi/api_gateway.json`](docs/openapi/api_gateway.json) |
+| Prompt catalog | Hosts reusable prompt templates and simple search endpoints. | 8001 | <http://localhost:8001/docs> | [`docs/openapi/prompt_catalog.json`](docs/openapi/prompt_catalog.json) |
+| Patient context | Serves mock EMR data and pre-normalised patient context payloads. | 8002 | <http://localhost:8002/docs> | [`docs/openapi/patient_context.json`](docs/openapi/patient_context.json) |
+| Chain executor | Resolves prompt chains, enriches them with patient context, and executes LLM calls with optional streaming. | 8003 | <http://localhost:8003/docs> | [`docs/openapi/chain_executor.json`](docs/openapi/chain_executor.json) |
 
-## Running the services with Docker Compose
+The OpenAPI documents above are generated from the live FastAPI applications and
+can be imported into tooling such as Postman or Stoplight. See
+[`docs/architecture.md`](docs/architecture.md) for a deeper dive into the orchestration
+strategy, provider selection, and prompt categorisation logic.
 
-The repository ships with container definitions for each FastAPI service plus a
-shared Python base image. To start the stack locally:
+## Environment setup
 
-1. Build the common base image:
+### Configure environment variables
 
-   ```bash
-   docker build -f Dockerfile.base -t ai-chat-ehr-base .
-   ```
-
-2. Bootstrap your environment configuration:
-
+1. Copy the example configuration and adjust it for your environment:
    ```bash
    cp .env.example .env
    ```
+2. Populate provider credentials (for OpenAI, Azure, Anthropic, or Vertex) and
+   update any overrides such as `DEFAULT_MODEL__PROVIDER` or Redis settings.
 
-   Update `.env` with any provider credentials or overrides that you need for
-   experimentation.
+### Option A: Local Python environment
 
-3. Launch the services and supporting Redis instance:
+1. Create and activate a Python 3.10 virtual environment.
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install the project in editable mode to pull in service dependencies.
+   ```bash
+   pip install -e .
+   ```
+3. Launch individual services with Uvicorn as needed:
+   ```bash
+   uvicorn services.prompt_catalog.app:app --reload --port 8001
+   uvicorn services.patient_context.app:app --reload --port 8002
+   uvicorn services.chain_executor.app:app --reload --port 8003
+   uvicorn services.api_gateway.app:app --reload --port 8000
+   ```
 
+### Option B: Docker Compose stack
+
+1. Build the shared base image (only required the first time or after Dockerfile changes):
+   ```bash
+   docker build -f Dockerfile.base -t ai-chat-ehr-base .
+   ```
+2. Start the prompt catalog, patient context, chain executor, and Redis services:
    ```bash
    docker compose up --build
    ```
+   The containers expose the service ports listed above on `localhost`. Use
+   `docker compose down` to stop the stack when you finish testing.
 
-   The compose file exposes the services on the following ports:
+## Request examples
 
-   * Prompt catalog – <http://localhost:8001>
-   * Patient context – <http://localhost:8002>
-   * Chain executor – <http://localhost:8003>
-   * Redis mock datastore – `localhost:6379`
+With the stack running locally, the following `curl` snippets exercise the core
+services:
 
-   Use `docker compose down` to stop the stack once you finish testing.
+* List all prompts in the catalog:
+  ```bash
+  curl http://localhost:8001/prompts | jq
+  ```
+* Retrieve patient context for the bundled sample patient (`patient_id=123456`):
+  ```bash
+  curl "http://localhost:8002/patients/context?patient_id=123456" | jq
+  ```
+* Execute a two-step chain that pulls patient context and drafts a clinical plan:
+  ```bash
+  curl -X POST http://localhost:8003/chains/execute \
+    -H "Content-Type: application/json" \
+    -d '{
+          "chain": ["patient_context", "clinical_plan"],
+          "patientId": "123456",
+          "variables": {
+            "patient_background": "Hypertension follow up visit for Ava Thompson.",
+            "encounter_overview": "Review vitals and adjust medications as needed."
+          },
+          "modelProvider": "openai/gpt-4o-mini"
+        }' | jq
+  ```
+* Stream chain output as server-sent events (SSE):
+  ```bash
+  curl -N http://localhost:8003/chains/execute/stream \
+    -H "Accept: text/event-stream" \
+    -H "Content-Type: application/json" \
+    -d '{
+          "chain": ["follow_up_questions"],
+          "patientId": "123456",
+          "variables": {
+            "patient_summary": "Summarise outstanding questions for the follow-up visit."
+          }
+        }'
+  ```
+* Check the gateway health endpoint (when the API gateway is running):
+  ```bash
+  curl http://localhost:8000/health | jq
+  ```
+
+These examples demonstrate the canonical request payload shapes; refer to the
+OpenAPI documentation for complete request/response schemas and error details.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,47 @@
+# Architecture overview
+
+## Chain execution lifecycle
+
+The chain executor service exposes buffered and streaming endpoints at
+`POST /chains/execute` and `POST /chains/execute/stream`. Each request is
+validated against `ChainExecutionRequest`, which accepts a list of prompt
+selectors, optional patient identifier, initial variables, and model overrides
+such as `modelProvider`, `model`, and `temperature`.
+Resolved requests are wrapped in a `_ChainExecutionContext` that captures the
+chosen language model, provider metadata, fetched patient context, resolved
+variables, and the ordered prompt steps that will be executed. Prompt selectors
+are normalised via the prompt catalog client: raw strings become temporary
+prompts, `ChatPromptKey` enums fetch catalog entries, and missing prompts raise a
+`PromptNotFoundError`.
+
+Before executing the chain, the service enriches the variable map with patient
+context JSON, derived context helpers, and any IDs supplied in the request.
+Each prompt step is compiled into a `PromptTemplate`, assigned a unique output
+key, and appended to the execution context. The buffered endpoint runs each
+`LLMChain` sequentially, updating the variable map and aggregating outputs for
+inclusion in the final `ChainExecutionResponse`. The streaming endpoint executes
+non-final steps the same way but streams incremental chunks from the final LLM
+step as server-sent events, emitting metadata, intermediate step payloads, and a
+final response envelope when completion succeeds or an error occurs.
+
+## Provider resolution
+
+`ChainExecutionRequest` defaults to `LLMProvider.OPENAI_GPT_35_TURBO`, but
+callers can override `modelProvider` or supply an explicit `model` name.
+`LLMProvider` enumerates the supported provider/model combinations and exposes a
+`create_client` helper that constructs the appropriate LangChain client using the
+shared settings for OpenAI, Azure, Anthropic, or Vertex. When a model override
+is supplied, the helper resolves the concrete `ModelSpec` and delegates client
+creation to the resolved provider, ensuring temperature overrides and backend
+capabilities are respected.
+
+## Prompt category inference
+
+Prompt metadata optionally includes `categories`, but when a prompt lacks labels
+the chain executor invokes `_ensure_prompt_categories` to infer them. The helper
+first inspects the prompt metadata and cached results; if no categories are
+available it instantiates a lazily-created `CategoryClassifier`. The classifier
+serialises the prompt payload to JSON, invokes its `LLMChain`, and parses the
+response into category slugs using a deterministic parser. Successful
+classifications are cached by a digest of the prompt metadata, and the inferred
+slugs are injected back into the prompt metadata for downstream consumers.

--- a/docs/openapi/api_gateway.json
+++ b/docs/openapi/api_gateway.json
@@ -1,0 +1,33 @@
+{
+  "info": {
+    "title": "AI Chat EHR API Gateway",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/health": {
+      "get": {
+        "description": "Return API gateway health information including dependency status.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Health Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Health",
+        "tags": [
+          "health"
+        ]
+      }
+    }
+  }
+}

--- a/docs/openapi/chain_executor.json
+++ b/docs/openapi/chain_executor.json
@@ -1,0 +1,2136 @@
+{
+  "components": {
+    "schemas": {
+      "Allergy": {
+        "description": "Allergy or intolerance record.",
+        "properties": {
+          "comments": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Comments"
+          },
+          "notedDate": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Noteddate"
+          },
+          "reaction": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reaction"
+          },
+          "severity": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Severity"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "substance": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Substance"
+          }
+        },
+        "title": "Allergy",
+        "type": "object"
+      },
+      "CarePlanItem": {
+        "description": "Entries in a care plan or set of recommendations.",
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "due": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Due"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          }
+        },
+        "title": "CarePlanItem",
+        "type": "object"
+      },
+      "CareTeamMember": {
+        "description": "Care team participants.",
+        "properties": {
+          "contact": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contact"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "organization": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Organization"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role"
+          }
+        },
+        "title": "CareTeamMember",
+        "type": "object"
+      },
+      "ChainExecutionRequest": {
+        "description": "Request payload describing a prompt chain to execute.",
+        "properties": {
+          "chain": {
+            "description": "Ordered prompts or raw instructions to execute",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ChatPromptKey"
+                },
+                {
+                  "$ref": "#/components/schemas/ChatPrompt-Input"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "minItems": 1,
+            "title": "Chain",
+            "type": "array"
+          },
+          "maxTokens": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional maximum number of tokens for the final response",
+            "title": "Maxtokens"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "description": "Arbitrary metadata for client bookkeeping",
+            "title": "Metadata",
+            "type": "object"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional model name override for the selected provider",
+            "title": "Model"
+          },
+          "modelProvider": {
+            "$ref": "#/components/schemas/LLMProvider",
+            "default": "openai/gpt-3.5-turbo",
+            "description": "Language model provider to use for execution"
+          },
+          "patientId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional patient identifier for context retrieval",
+            "title": "Patientid"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional legacy provider identifier; prefer 'model_provider'",
+            "title": "Provider"
+          },
+          "temperature": {
+            "anyOf": [
+              {
+                "maximum": 2.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional temperature override for generation",
+            "title": "Temperature"
+          },
+          "topP": {
+            "anyOf": [
+              {
+                "maximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional nucleus sampling parameter",
+            "title": "Topp"
+          },
+          "variables": {
+            "additionalProperties": true,
+            "description": "Initial variables supplied to the chain for template rendering",
+            "title": "Variables",
+            "type": "object"
+          }
+        },
+        "required": [
+          "chain"
+        ],
+        "title": "ChainExecutionRequest",
+        "type": "object"
+      },
+      "ChainExecutionResponse": {
+        "description": "Response payload returned after executing a prompt chain.",
+        "properties": {
+          "finalOutput": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Content produced by the final step",
+            "title": "Finaloutput"
+          },
+          "finalOutputKey": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Identifier for the final step in the chain",
+            "title": "Finaloutputkey"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "description": "Initial variables supplied for the execution",
+            "title": "Inputs",
+            "type": "object"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "description": "Arbitrary metadata associated with the run",
+            "title": "Metadata",
+            "type": "object"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Provider specific model name used for execution",
+            "title": "Model"
+          },
+          "modelProvider": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LLMProvider"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Canonical provider selected for execution"
+          },
+          "outputs": {
+            "additionalProperties": true,
+            "description": "Mapping of step output keys to generated text",
+            "title": "Outputs",
+            "type": "object"
+          },
+          "patientContext": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EHRPatientContext"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Patient context payload retrieved for execution"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "String representation of the provider used (deprecated)",
+            "title": "Provider"
+          },
+          "steps": {
+            "description": "Resolved steps that were executed as part of the chain",
+            "items": {
+              "$ref": "#/components/schemas/ChainStepResult"
+            },
+            "title": "Steps",
+            "type": "array"
+          }
+        },
+        "title": "ChainExecutionResponse",
+        "type": "object"
+      },
+      "ChainStepResult": {
+        "description": "Metadata describing a single executed step in a prompt chain.",
+        "properties": {
+          "outputKey": {
+            "description": "Key assigned to the step's output",
+            "title": "Outputkey",
+            "type": "string"
+          },
+          "prompt": {
+            "$ref": "#/components/schemas/ChatPrompt-Output",
+            "description": "Resolved prompt configuration for the step"
+          }
+        },
+        "required": [
+          "prompt",
+          "outputKey"
+        ],
+        "title": "ChainStepResult",
+        "type": "object"
+      },
+      "ChatPrompt-Input": {
+        "description": "Metadata describing a reusable chat prompt template.",
+        "properties": {
+          "chain": {
+            "description": "Sequence of additional prompts or raw instructions to execute prior to this prompt",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ChatPromptKey"
+                },
+                {
+                  "$ref": "#/components/schemas/ChatPrompt-Input"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "title": "Chain",
+            "type": "array"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Detailed explanation of the prompt's purpose",
+            "title": "Description"
+          },
+          "inputVariables": {
+            "description": "Names of variables expected by the template",
+            "items": {
+              "type": "string"
+            },
+            "title": "Inputvariables",
+            "type": "array"
+          },
+          "key": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ChatPromptKey"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Canonical identifier for the prompt"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "description": "Arbitrary metadata for the prompt",
+            "title": "Metadata",
+            "type": "object"
+          },
+          "template": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Prompt template text that may contain replacement variables",
+            "title": "Template"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Human readable label",
+            "title": "Title"
+          }
+        },
+        "title": "ChatPrompt",
+        "type": "object"
+      },
+      "ChatPrompt-Output": {
+        "description": "Metadata describing a reusable chat prompt template.",
+        "properties": {
+          "chain": {
+            "description": "Sequence of additional prompts or raw instructions to execute prior to this prompt",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ChatPromptKey"
+                },
+                {
+                  "$ref": "#/components/schemas/ChatPrompt-Output"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "title": "Chain",
+            "type": "array"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Detailed explanation of the prompt's purpose",
+            "title": "Description"
+          },
+          "inputVariables": {
+            "description": "Names of variables expected by the template",
+            "items": {
+              "type": "string"
+            },
+            "title": "Inputvariables",
+            "type": "array"
+          },
+          "key": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ChatPromptKey"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Canonical identifier for the prompt"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "description": "Arbitrary metadata for the prompt",
+            "title": "Metadata",
+            "type": "object"
+          },
+          "template": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Prompt template text that may contain replacement variables",
+            "title": "Template"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Human readable label",
+            "title": "Title"
+          }
+        },
+        "title": "ChatPrompt",
+        "type": "object"
+      },
+      "ChatPromptKey": {
+        "description": "Canonical identifiers for reusable chat prompts.",
+        "enum": [
+          "patient_context",
+          "patient_summary",
+          "differential_diagnosis",
+          "clinical_plan",
+          "follow_up_questions",
+          "patient_education",
+          "safety_checks",
+          "triage_assessment"
+        ],
+        "title": "ChatPromptKey",
+        "type": "string"
+      },
+      "ClinicalDocument": {
+        "description": "Structured clinical documents linked to the record.",
+        "properties": {
+          "author": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Author"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "createdAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Createdat"
+          },
+          "documentId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Documentid"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          }
+        },
+        "title": "ClinicalDocument",
+        "type": "object"
+      },
+      "ClinicalNote": {
+        "description": "Clinical note metadata and content.",
+        "properties": {
+          "author": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Author"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "createdAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Createdat"
+          },
+          "noteId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Noteid"
+          },
+          "noteType": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notetype"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          }
+        },
+        "title": "ClinicalNote",
+        "type": "object"
+      },
+      "EHRPatientContext": {
+        "description": "Patient context payload curated for chat workflows.",
+        "properties": {
+          "additionalNotes": {
+            "items": {
+              "$ref": "#/components/schemas/ClinicalNote"
+            },
+            "title": "Additionalnotes",
+            "type": "array"
+          },
+          "allergies": {
+            "items": {
+              "$ref": "#/components/schemas/Allergy"
+            },
+            "title": "Allergies",
+            "type": "array"
+          },
+          "assessment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assessment"
+          },
+          "careTeam": {
+            "items": {
+              "$ref": "#/components/schemas/CareTeamMember"
+            },
+            "title": "Careteam",
+            "type": "array"
+          },
+          "chiefComplaint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chiefcomplaint"
+          },
+          "clinicalDocuments": {
+            "items": {
+              "$ref": "#/components/schemas/ClinicalDocument"
+            },
+            "title": "Clinicaldocuments",
+            "type": "array"
+          },
+          "clinicalNotes": {
+            "items": {
+              "$ref": "#/components/schemas/ClinicalNote"
+            },
+            "title": "Clinicalnotes",
+            "type": "array"
+          },
+          "demographics": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PatientDemographics"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "encounters": {
+            "items": {
+              "$ref": "#/components/schemas/Encounter"
+            },
+            "title": "Encounters",
+            "type": "array"
+          },
+          "familyHistory": {
+            "items": {
+              "$ref": "#/components/schemas/FamilyHistoryItem"
+            },
+            "title": "Familyhistory",
+            "type": "array"
+          },
+          "followUpActions": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Followupactions",
+            "type": "array"
+          },
+          "goals": {
+            "items": {
+              "$ref": "#/components/schemas/CarePlanItem"
+            },
+            "title": "Goals",
+            "type": "array"
+          },
+          "historyOfPresentIllness": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Historyofpresentillness"
+          },
+          "imaging": {
+            "items": {
+              "$ref": "#/components/schemas/ImagingStudy"
+            },
+            "title": "Imaging",
+            "type": "array"
+          },
+          "immunizations": {
+            "items": {
+              "$ref": "#/components/schemas/Immunization"
+            },
+            "title": "Immunizations",
+            "type": "array"
+          },
+          "labResults": {
+            "items": {
+              "$ref": "#/components/schemas/LabResult"
+            },
+            "title": "Labresults",
+            "type": "array"
+          },
+          "medications": {
+            "items": {
+              "$ref": "#/components/schemas/Medication"
+            },
+            "title": "Medications",
+            "type": "array"
+          },
+          "plan": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Plan"
+          },
+          "problems": {
+            "items": {
+              "$ref": "#/components/schemas/Problem"
+            },
+            "title": "Problems",
+            "type": "array"
+          },
+          "procedures": {
+            "items": {
+              "$ref": "#/components/schemas/Procedure"
+            },
+            "title": "Procedures",
+            "type": "array"
+          },
+          "socialHistory": {
+            "items": {
+              "$ref": "#/components/schemas/SocialHistoryItem"
+            },
+            "title": "Socialhistory",
+            "type": "array"
+          },
+          "vitalSigns": {
+            "items": {
+              "$ref": "#/components/schemas/VitalSign"
+            },
+            "title": "Vitalsigns",
+            "type": "array"
+          }
+        },
+        "title": "EHRPatientContext",
+        "type": "object"
+      },
+      "Encounter": {
+        "description": "Basic information about a clinical encounter.",
+        "properties": {
+          "encounterId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Encounterid"
+          },
+          "end": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          },
+          "start": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          }
+        },
+        "title": "Encounter",
+        "type": "object"
+      },
+      "FamilyHistoryItem": {
+        "description": "Family history item.",
+        "properties": {
+          "condition": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Condition"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "relationship": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Relationship"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          }
+        },
+        "title": "FamilyHistoryItem",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "ImagingStudy": {
+        "description": "Summary details from imaging studies.",
+        "properties": {
+          "findings": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Findings"
+          },
+          "impression": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Impression"
+          },
+          "modality": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Modality"
+          },
+          "performedAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Performedat"
+          },
+          "study": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Study"
+          }
+        },
+        "title": "ImagingStudy",
+        "type": "object"
+      },
+      "Immunization": {
+        "description": "Immunization history details.",
+        "properties": {
+          "date": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "lotNumber": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lotnumber"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "vaccine": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vaccine"
+          }
+        },
+        "title": "Immunization",
+        "type": "object"
+      },
+      "LLMProvider": {
+        "description": "Enumerate supported provider/model combinations.",
+        "enum": [
+          "openai/gpt-3.5-turbo",
+          "openai/gpt-4o",
+          "openai/gpt-4o-mini",
+          "azure/gpt-4o",
+          "azure/gpt-4o-mini",
+          "anthropic/claude-3-haiku",
+          "anthropic/claude-3-sonnet",
+          "vertex/gemini-2.5-pro",
+          "vertex/gemini-2.5-flash"
+        ],
+        "title": "LLMProvider",
+        "type": "string"
+      },
+      "LabResult": {
+        "description": "Laboratory result details.",
+        "properties": {
+          "abnormalFlag": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Abnormalflag"
+          },
+          "collectedAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Collectedat"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "referenceRange": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Referencerange"
+          },
+          "resultedAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resultedat"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "testCode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Testcode"
+          },
+          "testName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Testname"
+          },
+          "unit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "title": "LabResult",
+        "type": "object"
+      },
+      "Medication": {
+        "description": "Medication order or administration details.",
+        "properties": {
+          "asNeeded": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Asneeded"
+          },
+          "dose": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dose"
+          },
+          "endDate": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Enddate"
+          },
+          "frequency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Frequency"
+          },
+          "indication": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Indication"
+          },
+          "instructions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instructions"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "route": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Route"
+          },
+          "startDate": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Startdate"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          }
+        },
+        "title": "Medication",
+        "type": "object"
+      },
+      "PatientDemographics": {
+        "description": "Structured demographic attributes about a patient.",
+        "properties": {
+          "address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Address"
+          },
+          "age": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Age"
+          },
+          "biologicalSex": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Biologicalsex"
+          },
+          "dateOfBirth": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dateofbirth"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "ethnicity": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ethnicity"
+          },
+          "firstName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Firstname"
+          },
+          "fullName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fullname"
+          },
+          "gender": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gender"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          },
+          "lastName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lastname"
+          },
+          "maritalStatus": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Maritalstatus"
+          },
+          "middleName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Middlename"
+          },
+          "mrn": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Medical record number",
+            "title": "Mrn"
+          },
+          "occupation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Occupation"
+          },
+          "patientId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Unique patient id",
+            "title": "Patientid"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "preferredContactMethod": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preferredcontactmethod"
+          },
+          "prefix": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prefix"
+          },
+          "pronouns": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pronouns"
+          },
+          "race": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Race"
+          },
+          "suffix": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suffix"
+          }
+        },
+        "title": "PatientDemographics",
+        "type": "object"
+      },
+      "Problem": {
+        "description": "Problem list entry.",
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "onset": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Onset"
+          },
+          "resolved": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolved"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          }
+        },
+        "title": "Problem",
+        "type": "object"
+      },
+      "Procedure": {
+        "description": "Procedures performed or planned for the patient.",
+        "properties": {
+          "date": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "performer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Performer"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          }
+        },
+        "title": "Procedure",
+        "type": "object"
+      },
+      "SocialHistoryItem": {
+        "description": "Social history elements relevant to the encounter.",
+        "properties": {
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "recordedAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recordedat"
+          }
+        },
+        "title": "SocialHistoryItem",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      },
+      "VitalSign": {
+        "description": "Individual vital sign measurement.",
+        "properties": {
+          "qualifier": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Qualifier"
+          },
+          "takenAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Takenat"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          },
+          "unit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "title": "VitalSign",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Chain Executor Service",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/chains/execute": {
+      "post": {
+        "description": "Execute a sequence of prompts using the configured language model provider.",
+        "operationId": "execute_chain_chains_execute_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChainExecutionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChainExecutionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Execute Chain",
+        "tags": [
+          "chains"
+        ]
+      }
+    },
+    "/chains/execute/stream": {
+      "post": {
+        "description": "Stream partial chain results as server-sent events.",
+        "operationId": "stream_chain_execution_chains_execute_stream_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChainExecutionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Stream Chain Execution",
+        "tags": [
+          "chains"
+        ]
+      }
+    },
+    "/health": {
+      "get": {
+        "description": "Return a simple health payload for orchestration checks.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Health Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Health",
+        "tags": [
+          "health"
+        ]
+      }
+    }
+  }
+}

--- a/docs/openapi/patient_context.json
+++ b/docs/openapi/patient_context.json
@@ -1,0 +1,1810 @@
+{
+  "components": {
+    "schemas": {
+      "Allergy": {
+        "description": "Allergy or intolerance record.",
+        "properties": {
+          "comments": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Comments"
+          },
+          "notedDate": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Noteddate"
+          },
+          "reaction": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reaction"
+          },
+          "severity": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Severity"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "substance": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Substance"
+          }
+        },
+        "title": "Allergy",
+        "type": "object"
+      },
+      "CarePlanItem": {
+        "description": "Entries in a care plan or set of recommendations.",
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "due": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Due"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          }
+        },
+        "title": "CarePlanItem",
+        "type": "object"
+      },
+      "CareTeamMember": {
+        "description": "Care team participants.",
+        "properties": {
+          "contact": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contact"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "organization": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Organization"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role"
+          }
+        },
+        "title": "CareTeamMember",
+        "type": "object"
+      },
+      "ClinicalDocument": {
+        "description": "Structured clinical documents linked to the record.",
+        "properties": {
+          "author": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Author"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "createdAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Createdat"
+          },
+          "documentId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Documentid"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          }
+        },
+        "title": "ClinicalDocument",
+        "type": "object"
+      },
+      "ClinicalNote": {
+        "description": "Clinical note metadata and content.",
+        "properties": {
+          "author": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Author"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "createdAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Createdat"
+          },
+          "noteId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Noteid"
+          },
+          "noteType": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notetype"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          }
+        },
+        "title": "ClinicalNote",
+        "type": "object"
+      },
+      "EHRPatientContext": {
+        "description": "Patient context payload curated for chat workflows.",
+        "properties": {
+          "additionalNotes": {
+            "items": {
+              "$ref": "#/components/schemas/ClinicalNote"
+            },
+            "title": "Additionalnotes",
+            "type": "array"
+          },
+          "allergies": {
+            "items": {
+              "$ref": "#/components/schemas/Allergy"
+            },
+            "title": "Allergies",
+            "type": "array"
+          },
+          "assessment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assessment"
+          },
+          "careTeam": {
+            "items": {
+              "$ref": "#/components/schemas/CareTeamMember"
+            },
+            "title": "Careteam",
+            "type": "array"
+          },
+          "chiefComplaint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chiefcomplaint"
+          },
+          "clinicalDocuments": {
+            "items": {
+              "$ref": "#/components/schemas/ClinicalDocument"
+            },
+            "title": "Clinicaldocuments",
+            "type": "array"
+          },
+          "clinicalNotes": {
+            "items": {
+              "$ref": "#/components/schemas/ClinicalNote"
+            },
+            "title": "Clinicalnotes",
+            "type": "array"
+          },
+          "demographics": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PatientDemographics"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "encounters": {
+            "items": {
+              "$ref": "#/components/schemas/Encounter"
+            },
+            "title": "Encounters",
+            "type": "array"
+          },
+          "familyHistory": {
+            "items": {
+              "$ref": "#/components/schemas/FamilyHistoryItem"
+            },
+            "title": "Familyhistory",
+            "type": "array"
+          },
+          "followUpActions": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Followupactions",
+            "type": "array"
+          },
+          "goals": {
+            "items": {
+              "$ref": "#/components/schemas/CarePlanItem"
+            },
+            "title": "Goals",
+            "type": "array"
+          },
+          "historyOfPresentIllness": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Historyofpresentillness"
+          },
+          "imaging": {
+            "items": {
+              "$ref": "#/components/schemas/ImagingStudy"
+            },
+            "title": "Imaging",
+            "type": "array"
+          },
+          "immunizations": {
+            "items": {
+              "$ref": "#/components/schemas/Immunization"
+            },
+            "title": "Immunizations",
+            "type": "array"
+          },
+          "labResults": {
+            "items": {
+              "$ref": "#/components/schemas/LabResult"
+            },
+            "title": "Labresults",
+            "type": "array"
+          },
+          "medications": {
+            "items": {
+              "$ref": "#/components/schemas/Medication"
+            },
+            "title": "Medications",
+            "type": "array"
+          },
+          "plan": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Plan"
+          },
+          "problems": {
+            "items": {
+              "$ref": "#/components/schemas/Problem"
+            },
+            "title": "Problems",
+            "type": "array"
+          },
+          "procedures": {
+            "items": {
+              "$ref": "#/components/schemas/Procedure"
+            },
+            "title": "Procedures",
+            "type": "array"
+          },
+          "socialHistory": {
+            "items": {
+              "$ref": "#/components/schemas/SocialHistoryItem"
+            },
+            "title": "Socialhistory",
+            "type": "array"
+          },
+          "vitalSigns": {
+            "items": {
+              "$ref": "#/components/schemas/VitalSign"
+            },
+            "title": "Vitalsigns",
+            "type": "array"
+          }
+        },
+        "title": "EHRPatientContext",
+        "type": "object"
+      },
+      "Encounter": {
+        "description": "Basic information about a clinical encounter.",
+        "properties": {
+          "encounterId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Encounterid"
+          },
+          "end": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          },
+          "start": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          }
+        },
+        "title": "Encounter",
+        "type": "object"
+      },
+      "FamilyHistoryItem": {
+        "description": "Family history item.",
+        "properties": {
+          "condition": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Condition"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "relationship": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Relationship"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          }
+        },
+        "title": "FamilyHistoryItem",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "ImagingStudy": {
+        "description": "Summary details from imaging studies.",
+        "properties": {
+          "findings": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Findings"
+          },
+          "impression": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Impression"
+          },
+          "modality": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Modality"
+          },
+          "performedAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Performedat"
+          },
+          "study": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Study"
+          }
+        },
+        "title": "ImagingStudy",
+        "type": "object"
+      },
+      "Immunization": {
+        "description": "Immunization history details.",
+        "properties": {
+          "date": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "lotNumber": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lotnumber"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "vaccine": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vaccine"
+          }
+        },
+        "title": "Immunization",
+        "type": "object"
+      },
+      "LabResult": {
+        "description": "Laboratory result details.",
+        "properties": {
+          "abnormalFlag": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Abnormalflag"
+          },
+          "collectedAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Collectedat"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "referenceRange": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Referencerange"
+          },
+          "resultedAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resultedat"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "testCode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Testcode"
+          },
+          "testName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Testname"
+          },
+          "unit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "title": "LabResult",
+        "type": "object"
+      },
+      "Medication": {
+        "description": "Medication order or administration details.",
+        "properties": {
+          "asNeeded": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Asneeded"
+          },
+          "dose": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dose"
+          },
+          "endDate": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Enddate"
+          },
+          "frequency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Frequency"
+          },
+          "indication": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Indication"
+          },
+          "instructions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instructions"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "route": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Route"
+          },
+          "startDate": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Startdate"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          }
+        },
+        "title": "Medication",
+        "type": "object"
+      },
+      "PatientDemographics": {
+        "description": "Structured demographic attributes about a patient.",
+        "properties": {
+          "address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Address"
+          },
+          "age": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Age"
+          },
+          "biologicalSex": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Biologicalsex"
+          },
+          "dateOfBirth": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dateofbirth"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "ethnicity": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ethnicity"
+          },
+          "firstName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Firstname"
+          },
+          "fullName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fullname"
+          },
+          "gender": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gender"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          },
+          "lastName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lastname"
+          },
+          "maritalStatus": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Maritalstatus"
+          },
+          "middleName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Middlename"
+          },
+          "mrn": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Medical record number",
+            "title": "Mrn"
+          },
+          "occupation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Occupation"
+          },
+          "patientId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Unique patient id",
+            "title": "Patientid"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "preferredContactMethod": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preferredcontactmethod"
+          },
+          "prefix": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prefix"
+          },
+          "pronouns": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pronouns"
+          },
+          "race": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Race"
+          },
+          "suffix": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suffix"
+          }
+        },
+        "title": "PatientDemographics",
+        "type": "object"
+      },
+      "PatientRecord": {
+        "description": "Aggregate structure capturing the patient's longitudinal record.",
+        "properties": {
+          "allergies": {
+            "items": {
+              "$ref": "#/components/schemas/Allergy"
+            },
+            "title": "Allergies",
+            "type": "array"
+          },
+          "careTeam": {
+            "items": {
+              "$ref": "#/components/schemas/CareTeamMember"
+            },
+            "title": "Careteam",
+            "type": "array"
+          },
+          "clinicalDocuments": {
+            "items": {
+              "$ref": "#/components/schemas/ClinicalDocument"
+            },
+            "title": "Clinicaldocuments",
+            "type": "array"
+          },
+          "clinicalNotes": {
+            "items": {
+              "$ref": "#/components/schemas/ClinicalNote"
+            },
+            "title": "Clinicalnotes",
+            "type": "array"
+          },
+          "demographics": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PatientDemographics"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "encounters": {
+            "items": {
+              "$ref": "#/components/schemas/Encounter"
+            },
+            "title": "Encounters",
+            "type": "array"
+          },
+          "familyHistory": {
+            "items": {
+              "$ref": "#/components/schemas/FamilyHistoryItem"
+            },
+            "title": "Familyhistory",
+            "type": "array"
+          },
+          "imaging": {
+            "items": {
+              "$ref": "#/components/schemas/ImagingStudy"
+            },
+            "title": "Imaging",
+            "type": "array"
+          },
+          "immunizations": {
+            "items": {
+              "$ref": "#/components/schemas/Immunization"
+            },
+            "title": "Immunizations",
+            "type": "array"
+          },
+          "labResults": {
+            "items": {
+              "$ref": "#/components/schemas/LabResult"
+            },
+            "title": "Labresults",
+            "type": "array"
+          },
+          "medications": {
+            "items": {
+              "$ref": "#/components/schemas/Medication"
+            },
+            "title": "Medications",
+            "type": "array"
+          },
+          "problems": {
+            "items": {
+              "$ref": "#/components/schemas/Problem"
+            },
+            "title": "Problems",
+            "type": "array"
+          },
+          "procedures": {
+            "items": {
+              "$ref": "#/components/schemas/Procedure"
+            },
+            "title": "Procedures",
+            "type": "array"
+          },
+          "socialHistory": {
+            "items": {
+              "$ref": "#/components/schemas/SocialHistoryItem"
+            },
+            "title": "Socialhistory",
+            "type": "array"
+          },
+          "vitalSigns": {
+            "items": {
+              "$ref": "#/components/schemas/VitalSign"
+            },
+            "title": "Vitalsigns",
+            "type": "array"
+          }
+        },
+        "title": "PatientRecord",
+        "type": "object"
+      },
+      "Problem": {
+        "description": "Problem list entry.",
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "onset": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Onset"
+          },
+          "resolved": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolved"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          }
+        },
+        "title": "Problem",
+        "type": "object"
+      },
+      "Procedure": {
+        "description": "Procedures performed or planned for the patient.",
+        "properties": {
+          "date": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "performer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Performer"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          }
+        },
+        "title": "Procedure",
+        "type": "object"
+      },
+      "SocialHistoryItem": {
+        "description": "Social history elements relevant to the encounter.",
+        "properties": {
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "recordedAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recordedat"
+          }
+        },
+        "title": "SocialHistoryItem",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      },
+      "VitalSign": {
+        "description": "Individual vital sign measurement.",
+        "properties": {
+          "qualifier": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Qualifier"
+          },
+          "takenAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Takenat"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          },
+          "unit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "title": "VitalSign",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Patient Context Service",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/health": {
+      "get": {
+        "description": "Return a simple health payload for orchestration checks.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Health Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Health",
+        "tags": [
+          "health"
+        ]
+      }
+    },
+    "/patients/context": {
+      "get": {
+        "description": "Return the chat-oriented patient context for ``patient_id``.",
+        "operationId": "read_patient_context_patients_context_get",
+        "parameters": [
+          {
+            "description": "Unique identifier for the patient",
+            "in": "query",
+            "name": "patient_id",
+            "required": true,
+            "schema": {
+              "description": "Unique identifier for the patient",
+              "title": "Patient Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EHRPatientContext"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Read Patient Context",
+        "tags": [
+          "patients"
+        ]
+      }
+    },
+    "/patients/{patient_id}": {
+      "get": {
+        "description": "Return the normalized patient record for ``patient_id``.",
+        "operationId": "read_patient_record_patients__patient_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "patient_id",
+            "required": true,
+            "schema": {
+              "title": "Patient Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PatientRecord"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Read Patient Record",
+        "tags": [
+          "patients"
+        ]
+      }
+    }
+  }
+}

--- a/docs/openapi/prompt_catalog.json
+++ b/docs/openapi/prompt_catalog.json
@@ -1,0 +1,372 @@
+{
+  "components": {
+    "schemas": {
+      "ChatPrompt": {
+        "description": "Metadata describing a reusable chat prompt template.",
+        "properties": {
+          "chain": {
+            "description": "Sequence of additional prompts or raw instructions to execute prior to this prompt",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ChatPromptKey"
+                },
+                {
+                  "$ref": "#/components/schemas/ChatPrompt"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "title": "Chain",
+            "type": "array"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Detailed explanation of the prompt's purpose",
+            "title": "Description"
+          },
+          "inputVariables": {
+            "description": "Names of variables expected by the template",
+            "items": {
+              "type": "string"
+            },
+            "title": "Inputvariables",
+            "type": "array"
+          },
+          "key": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ChatPromptKey"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Canonical identifier for the prompt"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "description": "Arbitrary metadata for the prompt",
+            "title": "Metadata",
+            "type": "object"
+          },
+          "template": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Prompt template text that may contain replacement variables",
+            "title": "Template"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Human readable label",
+            "title": "Title"
+          }
+        },
+        "title": "ChatPrompt",
+        "type": "object"
+      },
+      "ChatPromptKey": {
+        "description": "Canonical identifiers for reusable chat prompts.",
+        "enum": [
+          "patient_context",
+          "patient_summary",
+          "differential_diagnosis",
+          "clinical_plan",
+          "follow_up_questions",
+          "patient_education",
+          "safety_checks",
+          "triage_assessment"
+        ],
+        "title": "ChatPromptKey",
+        "type": "string"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "PromptCollectionResponse": {
+        "description": "Response payload containing a collection of prompts.",
+        "properties": {
+          "prompts": {
+            "items": {
+              "$ref": "#/components/schemas/ChatPrompt"
+            },
+            "title": "Prompts",
+            "type": "array"
+          }
+        },
+        "title": "PromptCollectionResponse",
+        "type": "object"
+      },
+      "PromptResponse": {
+        "description": "Response payload containing a single prompt.",
+        "properties": {
+          "prompt": {
+            "$ref": "#/components/schemas/ChatPrompt"
+          }
+        },
+        "required": [
+          "prompt"
+        ],
+        "title": "PromptResponse",
+        "type": "object"
+      },
+      "PromptSearchRequest": {
+        "description": "Search criteria for locating prompts.",
+        "properties": {
+          "key": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ChatPromptKey"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional canonical prompt key to filter by."
+          },
+          "limit": {
+            "default": 20,
+            "description": "Maximum number of prompts to include in the response.",
+            "maximum": 50.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "query": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Free-text query to match against prompt metadata and template.",
+            "title": "Query"
+          }
+        },
+        "title": "PromptSearchRequest",
+        "type": "object"
+      },
+      "PromptSearchResponse": {
+        "description": "Response payload containing search results.",
+        "properties": {
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/ChatPrompt"
+            },
+            "title": "Results",
+            "type": "array"
+          }
+        },
+        "title": "PromptSearchResponse",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Prompt Catalog Service",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/health": {
+      "get": {
+        "description": "Return a simple health payload for orchestration checks.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Health Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Health",
+        "tags": [
+          "health"
+        ]
+      }
+    },
+    "/prompts": {
+      "get": {
+        "description": "Return all prompts registered in the catalog.",
+        "operationId": "list_prompts_prompts_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromptCollectionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Prompts",
+        "tags": [
+          "prompts"
+        ]
+      }
+    },
+    "/prompts/search": {
+      "post": {
+        "description": "Search prompts using structured criteria.",
+        "operationId": "search_prompts_prompts_search_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromptSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromptSearchResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Search Prompts",
+        "tags": [
+          "prompts"
+        ]
+      }
+    },
+    "/prompts/{prompt_id}": {
+      "get": {
+        "description": "Return a single prompt by ``prompt_id``.",
+        "operationId": "get_prompt_prompts__prompt_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "prompt_id",
+            "required": true,
+            "schema": {
+              "title": "Prompt Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromptResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Prompt",
+        "tags": [
+          "prompts"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- expand the README with a service overview, setup instructions, and concrete request examples
- generate and check in OpenAPI specifications for every FastAPI service and link them from the docs
- add an architecture overview covering chain execution flow, provider resolution, and prompt category inference

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d332b234ec8330919f0ddde9aff5b5