### PR TITLE
Add VSCode launch and task configurations for microservices

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,84 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "API Gateway",
+            "type": "python",
+            "request": "launch",
+            "module": "uvicorn",
+            "args": [
+                "services.api_gateway.app:app",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8000"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "envFile": "${workspaceFolder}/.env",
+            "preLaunchTask": "pip install (workspace)"
+        },
+        {
+            "name": "Prompt Catalog",
+            "type": "python",
+            "request": "launch",
+            "module": "uvicorn",
+            "args": [
+                "services.prompt_catalog.main:app",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8001"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "envFile": "${workspaceFolder}/.env",
+            "preLaunchTask": "pip install (workspace)"
+        },
+        {
+            "name": "Patient Context",
+            "type": "python",
+            "request": "launch",
+            "module": "uvicorn",
+            "args": [
+                "services.patient_context.main:app",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8002"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "envFile": "${workspaceFolder}/.env",
+            "preLaunchTask": "pip install (workspace)"
+        },
+        {
+            "name": "Chain Executor",
+            "type": "python",
+            "request": "launch",
+            "module": "uvicorn",
+            "args": [
+                "services.chain_executor.main:app",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8003"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "envFile": "${workspaceFolder}/.env",
+            "preLaunchTask": "pip install (workspace)"
+        }
+    ],
+    "compounds": [
+        {
+            "name": "All Microservices",
+            "configurations": [
+                "API Gateway",
+                "Prompt Catalog",
+                "Patient Context",
+                "Chain Executor"
+            ]
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,126 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "pip install (workspace)",
+            "type": "process",
+            "command": "${command:python.interpreterPath}",
+            "args": [
+                "-m",
+                "pip",
+                "install",
+                "-e",
+                "."
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared",
+                "clear": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Run API Gateway",
+            "type": "process",
+            "command": "${command:python.interpreterPath}",
+            "args": [
+                "-m",
+                "uvicorn",
+                "services.api_gateway.app:app",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8000",
+                "--reload"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            },
+            "problemMatcher": [],
+            "dependsOn": "pip install (workspace)",
+            "dependsOrder": "sequence"
+        },
+        {
+            "label": "Run Prompt Catalog",
+            "type": "process",
+            "command": "${command:python.interpreterPath}",
+            "args": [
+                "-m",
+                "uvicorn",
+                "services.prompt_catalog.main:app",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8001",
+                "--reload"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            },
+            "problemMatcher": [],
+            "dependsOn": "pip install (workspace)",
+            "dependsOrder": "sequence"
+        },
+        {
+            "label": "Run Patient Context",
+            "type": "process",
+            "command": "${command:python.interpreterPath}",
+            "args": [
+                "-m",
+                "uvicorn",
+                "services.patient_context.main:app",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8002",
+                "--reload"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            },
+            "problemMatcher": [],
+            "dependsOn": "pip install (workspace)",
+            "dependsOrder": "sequence"
+        },
+        {
+            "label": "Run Chain Executor",
+            "type": "process",
+            "command": "${command:python.interpreterPath}",
+            "args": [
+                "-m",
+                "uvicorn",
+                "services.chain_executor.main:app",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8003",
+                "--reload"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            },
+            "problemMatcher": [],
+            "dependsOn": "pip install (workspace)",
+            "dependsOrder": "sequence"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- add VSCode task definitions to install dependencies and run each microservice with reload enabled
- configure VSCode launch configurations for each service with a compound to start them together and a pre-launch pip install step

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d333e7640c8330b8d25d9f94a713cc