### PR TITLE
Fix circular import in prompt builder

### DIFF
--- a/shared/llm/prompt_builder.py
+++ b/shared/llm/prompt_builder.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Mapping, Sequence
 
 from langchain.prompts import PromptTemplate
 
-from shared.models import (
+from shared.models.chat import (
     Allergy,
     CarePlanItem,
     ChatPrompt,


### PR DESCRIPTION
## Summary
- update `prompt_builder` to import chat models directly and avoid the shared models package re-export

## Testing
- pytest tests/chain_executor/test_execute_chain.py

------
https://chatgpt.com/codex/tasks/task_e_68d338f867a08330a71bc3e8fb404e9d