### PR TITLE
Fix Vertex AI package constraint

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -30,7 +30,7 @@ RUN pip install --no-cache-dir \
         "langchain-community==0.3.27" \
         "langchain-openai>=0.3,<0.4" \
         "langchain-anthropic>=0.3,<0.4" \
-        "langchain-google-vertexai>=0.3,<0.4" \
+        "langchain-google-vertexai==2.1.2" \
         "httpx>=0.27,<0.28" \
         "pydantic-settings>=2.1,<3" \
         "python-dotenv>=1.0,<2" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "langchain-community==0.3.27",
     "langchain-openai>=0.3,<0.4",
     "langchain-anthropic>=0.3,<0.4",
-    "langchain-google-vertexai>=0.3,<0.4",
+    "langchain-google-vertexai==2.1.2",
     "httpx>=0.27,<0.28",
     "pydantic-settings>=2.1,<3",
     "python-dotenv>=1.0,<2",


### PR DESCRIPTION
## Summary
- pin langchain-google-vertexai to version 2.1.2 in the Python project dependencies
- align the base Docker image dependency list with the same Vertex AI version

## Testing
- ⚠️ `pip install -e .` *(fails: proxy in the execution environment blocks access to PyPI)*

------
https://chatgpt.com/codex/tasks/task_e_68d414adedfc833080adc492a0fd881c