### PR TITLE
Fix langchain-core dependency constraint mismatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "fastapi>=0.110,<1",
     "uvicorn[standard]>=0.29,<0.30",
     "langchain==0.3.27",
-    "langchain-core==0.3.27",
+    "langchain-core>=0.3.72,<1",
     "langchain-community==0.3.27",
     "langchain-openai>=0.3,<0.4",
     "langchain-anthropic>=0.3,<0.4",


### PR DESCRIPTION
## Summary
- update the langchain-core dependency constraint so it is compatible with langchain 0.3.27

## Testing
- pip install -e . *(fails: proxy prevented downloading setuptools build dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d41661d3948330b156aa5e349c47e5