### PR TITLE
Adjust httpx version constraint for Vertex AI

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -31,7 +31,7 @@ RUN pip install --no-cache-dir \
         "langchain-openai>=0.3,<0.4" \
         "langchain-anthropic>=0.3,<0.4" \
         "langchain-google-vertexai==2.1.2" \
-        "httpx>=0.27,<0.28" \
+        "httpx>=0.28,<0.29" \
         "pydantic-settings>=2.1,<3" \
         "python-dotenv>=1.0,<2" \
         "openai>=1.14,<2" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "langchain-openai>=0.3,<0.4",
     "langchain-anthropic>=0.3,<0.4",
     "langchain-google-vertexai==2.1.2",
-    "httpx>=0.27,<0.28",
+    "httpx>=0.28,<0.29",
     "pydantic-settings>=2.1,<3",
     "python-dotenv>=1.0,<2",
     "openai>=1.14,<2",


### PR DESCRIPTION
## Summary
- update the project dependency constraint to allow httpx 0.28.x so it remains compatible with langchain-google-vertexai 2.1.2
- reflect the relaxed httpx version range in the base Dockerfile to keep images in sync

## Testing
- ⚠️ `python -m pip install -e .` *(fails in the execution environment: proxy prevents downloading build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d417ac42588330bb0acc0c72d8758b