### PR TITLE
Handle non-positive prompt search limits

### DIFF
--- a/services/prompt_catalog/repositories.py
+++ b/services/prompt_catalog/repositories.py
@@ -50,6 +50,9 @@ class PromptRepository:
         normalized_key = self._normalize_identifier(str(key)) if key else None
         normalized_query = query.lower().strip() if query else None
 
+        if limit <= 0:
+            return []
+
         results: list[ChatPrompt] = []
         for identifier, prompt in self._prompts.items():
             if normalized_key and identifier != normalized_key:
@@ -59,7 +62,7 @@ class PromptRepository:
                 continue
 
             results.append(prompt)
-            if 0 < limit <= len(results):
+            if len(results) >= limit:
                 break
         return results
 

--- a/tests/prompt_catalog/test_repositories.py
+++ b/tests/prompt_catalog/test_repositories.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from shared.models.chat import ChatPrompt
+
+from services.prompt_catalog.repositories import PromptRepository
+
+
+def _create_repository() -> PromptRepository:
+    prompt = ChatPrompt(
+        title="Example Prompt",
+        template="Hello {name}",
+        input_variables=["name"],
+    )
+    return PromptRepository([prompt])
+
+
+@pytest.mark.asyncio
+async def test_search_prompts_negative_limit_returns_empty_list() -> None:
+    repository = _create_repository()
+
+    results = await repository.search_prompts(limit=-5)
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_prompts_zero_limit_returns_empty_list() -> None:
+    repository = _create_repository()
+
+    results = await repository.search_prompts(limit=0)
+
+    assert results == []


### PR DESCRIPTION
## Summary
- prevent prompt catalog searches from returning results when the requested limit is zero or negative
- stop iterating once the requested number of matches has been collected
- add async regression tests covering zero and negative search limits

## Testing
- pytest tests/prompt_catalog/test_repositories.py *(fails: missing required dependency `pydantic` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d840024b1083308919acda9c03e8ce