### PR TITLE
Fix prompt lookup normalization for ChatPromptKey values

### DIFF
--- a/tests/prompt_catalog/test_repositories.py
+++ b/tests/prompt_catalog/test_repositories.py
@@ -7,13 +7,14 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from shared.models.chat import ChatPrompt
+from shared.models.chat import ChatPrompt, ChatPromptKey
 
 from services.prompt_catalog.repositories import PromptRepository
 
 
 def _create_repository() -> PromptRepository:
     prompt = ChatPrompt(
+        key=ChatPromptKey.PATIENT_CONTEXT,
         title="Example Prompt",
         template="Hello {name}",
         input_variables=["name"],
@@ -37,3 +38,23 @@ async def test_search_prompts_zero_limit_returns_empty_list() -> None:
     results = await repository.search_prompts(limit=0)
 
     assert results == []
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_accepts_string_identifier() -> None:
+    repository = _create_repository()
+
+    result = await repository.get_prompt("patient_context")
+
+    assert result is not None
+    assert result.key is ChatPromptKey.PATIENT_CONTEXT
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_accepts_enum_repr() -> None:
+    repository = _create_repository()
+
+    result = await repository.get_prompt("ChatPromptKey.PATIENT_CONTEXT")
+
+    assert result is not None
+    assert result.key is ChatPromptKey.PATIENT_CONTEXT


### PR DESCRIPTION
## Summary
- normalize prompt repository identifiers without losing ChatPromptKey values
- add regression tests covering string-based prompt lookups

## Testing
- pytest tests/prompt_catalog/test_repositories.py *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68d8424e29dc83309620bd83534151cf