### PR TITLE
Improve prompt identifier normalization

### DIFF
--- a/services/prompt_catalog/repositories.py
+++ b/services/prompt_catalog/repositories.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
-from shared.models.chat import ChatPrompt, ChatPromptKey
+from shared.models.chat import ChatPrompt, ChatPromptKey, _match_prompt_key
 
 
 class PromptRepository:
@@ -104,6 +104,10 @@ class PromptRepository:
         stripped = value.strip()
         if not stripped:
             return ""
+
+        matched_key = _match_prompt_key(stripped)
+        if matched_key is not None:
+            return matched_key.value
 
         lowered = stripped.lower()
         enum_prefix = f"{ChatPromptKey.__name__.lower()}"


### PR DESCRIPTION
## Summary
- allow the prompt catalog repository to normalize identifiers using the shared prompt-key matcher
- ensure lookups succeed when callers supply human-readable key variants (e.g. "Patient Context")

## Testing
- not run (project dependencies such as httpx and pydantic are unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d843e793048330a570232924d7a336