### PR TITLE
Preserve prompt variable ordering

### DIFF
--- a/shared/llm/prompt_builder.py
+++ b/shared/llm/prompt_builder.py
@@ -80,14 +80,14 @@ def build_prompt_template(prompt: EHRPrompt) -> PromptTemplateSpec:
     except ValueError as exc:  # pragma: no cover - defensive programming
         raise InvalidPromptTemplateError(str(exc)) from exc
 
-    declared = set(prompt.input_variables or [])
-    derived = set(template.input_variables)
+    declared = tuple(prompt.input_variables or [])
+    derived = tuple(dict.fromkeys(template.input_variables))
 
-    missing_declared = declared - derived
+    missing_declared = set(declared) - set(derived)
     if missing_declared:
         raise PromptVariableMismatchError(sorted(missing_declared))
 
-    return PromptTemplateSpec(template=template, input_variables=tuple(sorted(derived)))
+    return PromptTemplateSpec(template=template, input_variables=derived)
 
 
 ContextTransformer = Callable[[EHRPatientContext | None], Any]


### PR DESCRIPTION
## Summary
- ensure prompt template variables preserve their original order when materializing a PromptTemplateSpec
- keep duplicate handling deterministic while still validating declared variables

## Testing
- pytest *(fails: missing third-party dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d847fd67548330ac5b2dbea3a9b0d4