### PR TITLE
Handle blank metadata identifiers in prompt repository

### DIFF
--- a/services/prompt_catalog/repositories.py
+++ b/services/prompt_catalog/repositories.py
@@ -87,11 +87,21 @@ class PromptRepository:
         """Return the canonical identifier for ``prompt`` for dictionary storage."""
 
         if prompt.key is not None:
-            return self._normalize_identifier(prompt.key)
+            identifier = self._normalize_identifier(prompt.key)
+            if identifier:
+                return identifier
+
         if prompt.metadata and "id" in prompt.metadata:
-            return self._normalize_identifier(str(prompt.metadata["id"]))
+            raw_identifier = prompt.metadata.get("id")
+            if raw_identifier is not None:
+                identifier = self._normalize_identifier(str(raw_identifier))
+                if identifier:
+                    return identifier
+
         if prompt.title:
-            return self._normalize_identifier(prompt.title)
+            identifier = self._normalize_identifier(prompt.title)
+            if identifier:
+                return identifier
         raise ValueError("Prompt requires either a key, metadata id, or title for identification")
 
     @staticmethod

--- a/tests/prompt_catalog/test_repositories.py
+++ b/tests/prompt_catalog/test_repositories.py
@@ -58,3 +58,19 @@ async def test_get_prompt_accepts_enum_repr() -> None:
 
     assert result is not None
     assert result.key is ChatPromptKey.PATIENT_CONTEXT
+
+
+@pytest.mark.asyncio
+async def test_prompt_identifier_skips_blank_metadata_id() -> None:
+    prompt = ChatPrompt(
+        title="Example Prompt",
+        template="Hello",
+        metadata={"id": "   "},
+    )
+    repository = PromptRepository([prompt])
+
+    empty_lookup = await repository.get_prompt("   ")
+    title_lookup = await repository.get_prompt("Example Prompt")
+
+    assert empty_lookup is None
+    assert title_lookup is prompt


### PR DESCRIPTION
## Summary
- skip storing prompts under empty identifiers when metadata IDs normalize to blank values
- fall back to titles for identification and cover the scenario with a regression test

## Testing
- pytest tests/prompt_catalog/test_repositories.py *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68d84ce7c1ac8330a67de05571e51fd9