### PR TITLE
Fix model override parsing for double colon identifiers

### DIFF
--- a/shared/llm/llmmodels.py
+++ b/shared/llm/llmmodels.py
@@ -275,7 +275,7 @@ def _split_backend(identifier: str) -> Tuple[Optional[str], Optional[str]]:
 
 def _extract_model_override(raw_identifier: str) -> str:
     candidate = raw_identifier.strip()
-    for token in ("/", ":", "::"):
+    for token in ("::", "/", ":"):
         if token in candidate:
             candidate = candidate.split(token, 1)[1]
             break

--- a/tests/shared/test_providers.py
+++ b/tests/shared/test_providers.py
@@ -122,6 +122,20 @@ def test_resolve_model_spec_defaults_to_openai_when_provider_missing() -> None:
     assert spec.canonical_name == providers.LLMProvider.OPENAI_GPT_35_TURBO.value
 
 
+def test_resolve_model_spec_strips_double_colon_overrides() -> None:
+    providers = importlib.import_module("shared.llm.providers")
+    llmmodels = importlib.import_module("shared.llm.llmmodels")
+
+    spec = llmmodels.resolve_model_spec(
+        "azure::custom-deployment",
+        provider_hint=providers.LLMProvider.AZURE_GPT_4O,
+    )
+
+    assert spec.provider is providers.LLMProvider.AZURE_GPT_4O
+    assert spec.model_name == "custom-deployment"
+    assert spec.canonical_name == "azure/custom-deployment"
+
+
 def test_vertex_client_raises_when_env_credentials_missing(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- ensure model override parsing strips double-colon prefixes before delegating to providers
- add a regression test covering Azure deployment overrides that include a double-colon separator

## Testing
- pytest tests/shared/test_providers.py -k double_colon *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68d850b7e7d083308450f5326d4ad0de