### PR TITLE
Group microservice debug sessions in VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,11 @@
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
             "envFile": "${workspaceFolder}/.env",
-            "preLaunchTask": "pip install (workspace)"
+            "preLaunchTask": "pip install (workspace)",
+            "presentation": {
+                "group": "Microservices",
+                "order": 1
+            }
         },
         {
             "name": "Prompt Catalog",
@@ -33,7 +37,11 @@
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
             "envFile": "${workspaceFolder}/.env",
-            "preLaunchTask": "pip install (workspace)"
+            "preLaunchTask": "pip install (workspace)",
+            "presentation": {
+                "group": "Microservices",
+                "order": 2
+            }
         },
         {
             "name": "Patient Context",
@@ -50,7 +58,11 @@
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
             "envFile": "${workspaceFolder}/.env",
-            "preLaunchTask": "pip install (workspace)"
+            "preLaunchTask": "pip install (workspace)",
+            "presentation": {
+                "group": "Microservices",
+                "order": 3
+            }
         },
         {
             "name": "Chain Executor",
@@ -67,7 +79,11 @@
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
             "envFile": "${workspaceFolder}/.env",
-            "preLaunchTask": "pip install (workspace)"
+            "preLaunchTask": "pip install (workspace)",
+            "presentation": {
+                "group": "Microservices",
+                "order": 4
+            }
         }
     ],
     "compounds": [
@@ -78,7 +94,8 @@
                 "Prompt Catalog",
                 "Patient Context",
                 "Chain Executor"
-            ]
+            ],
+            "stopAll": true
         }
     ]
 }


### PR DESCRIPTION
## Summary
- group each microservice debug configuration under a shared "Microservices" presentation grouping
- ensure the "All Microservices" compound session stops every microservice together with a single action

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8674a4da083308f57ca9746b56dff