### PR TITLE
Ensure LangChain compatibility for LLM adapters

### DIFF
--- a/shared/llm/adapters/_base.py
+++ b/shared/llm/adapters/_base.py
@@ -66,6 +66,24 @@ def apply_temperature(kwargs: Dict[str, Any], temperature: Optional[float]) -> N
         kwargs["temperature"] = float(temperature)
 
 
+def ensure_langchain_compat(model: BaseLanguageModel) -> BaseLanguageModel:
+    """Ensure a model exposes modern LangChain invocation methods."""
+
+    def _ensure_method(target: str, candidates: tuple[str, ...]) -> None:
+        existing = getattr(model, target, None)
+        if callable(existing):
+            return
+        for candidate_name in candidates:
+            candidate = getattr(model, candidate_name, None)
+            if callable(candidate):
+                setattr(model, target, candidate)
+                break
+
+    _ensure_method("invoke", ("__call__", "predict", "generate"))
+    _ensure_method("ainvoke", ("apredict", "agenerate"))
+    return model
+
+
 def _log_retry(label: str, method_name: str, retry_state: RetryCallState) -> None:
     exception = None
     if retry_state.outcome is not None and retry_state.outcome.failed:
@@ -184,6 +202,7 @@ __all__ = [
     "DEFAULT_MAX_RETRIES",
     "resolve_settings",
     "apply_temperature",
+    "ensure_langchain_compat",
     "attach_retry",
     "filter_model_kwargs",
 ]

--- a/shared/llm/adapters/anthropic.py
+++ b/shared/llm/adapters/anthropic.py
@@ -12,6 +12,7 @@ from ._base import (
     DEFAULT_MAX_RETRIES,
     attach_retry,
     apply_temperature,
+    ensure_langchain_compat,
     filter_model_kwargs,
     resolve_settings,
 )
@@ -68,6 +69,7 @@ def get_chat_model(
 
     model_kwargs = filter_model_kwargs(ChatAnthropic, candidate_kwargs)
     model = ChatAnthropic(**model_kwargs)
+    model = ensure_langchain_compat(model)
     return attach_retry(
         model,
         label=f"anthropic/{model_name}",

--- a/shared/llm/adapters/azure.py
+++ b/shared/llm/adapters/azure.py
@@ -12,6 +12,7 @@ from ._base import (
     DEFAULT_MAX_RETRIES,
     attach_retry,
     apply_temperature,
+    ensure_langchain_compat,
     filter_model_kwargs,
     resolve_settings,
 )
@@ -99,6 +100,7 @@ def get_chat_model(
 
     model_kwargs = filter_model_kwargs(AzureChatOpenAI, candidate_kwargs)
     model = AzureChatOpenAI(**model_kwargs)
+    model = ensure_langchain_compat(model)
     return attach_retry(
         model,
         label=f"azure/{deployment_name}",

--- a/shared/llm/adapters/openai.py
+++ b/shared/llm/adapters/openai.py
@@ -12,6 +12,7 @@ from ._base import (
     DEFAULT_MAX_RETRIES,
     attach_retry,
     apply_temperature,
+    ensure_langchain_compat,
     filter_model_kwargs,
     resolve_settings,
 )
@@ -73,6 +74,7 @@ def get_chat_model(
 
     model_kwargs = filter_model_kwargs(ChatOpenAI, candidate_kwargs)
     model = ChatOpenAI(**model_kwargs)
+    model = ensure_langchain_compat(model)
     return attach_retry(
         model,
         label=f"openai/{model_name}",

--- a/shared/llm/adapters/vertex.py
+++ b/shared/llm/adapters/vertex.py
@@ -14,6 +14,7 @@ from ._base import (
     DEFAULT_MAX_RETRIES,
     attach_retry,
     apply_temperature,
+    ensure_langchain_compat,
     filter_model_kwargs,
     resolve_settings,
 )
@@ -129,6 +130,7 @@ def get_chat_model(
 
     model_kwargs = filter_model_kwargs(ChatVertexAI, candidate_kwargs)
     model = ChatVertexAI(**model_kwargs)
+    model = ensure_langchain_compat(model)
     return attach_retry(
         model,
         label=f"vertex/{resolved_model_name}",


### PR DESCRIPTION
## Summary
- add a helper that ensures language models expose modern LangChain invocation methods
- apply the compatibility helper to each chat adapter so invoke is available when using legacy model classes

## Testing
- pytest tests/shared/llm -q

------
https://chatgpt.com/codex/tasks/task_e_68d869b2951883308b8c052c1186183d