### PR TITLE
Fix patient context JSON serialization in chain executor

### DIFF
--- a/services/chain_executor/app.py
+++ b/services/chain_executor/app.py
@@ -717,9 +717,13 @@ async def _build_execution_context(
     if patient_context is not None:
         context_dict = patient_context.model_dump(by_alias=True, exclude_none=True)
         variables.setdefault("patient_context", context_dict)
+
+        json_ready_context = patient_context.model_dump(
+            mode="json", by_alias=True, exclude_none=True
+        )
         variables.setdefault(
             "patient_context_json",
-            json.dumps(context_dict, ensure_ascii=False, indent=2),
+            json.dumps(json_ready_context, ensure_ascii=False, indent=2),
         )
         available_variables.update({"patient_context", "patient_context_json"})
 


### PR DESCRIPTION
## Summary
- ensure patient_context_json is built from a JSON-serializable payload
- preserve the existing patient_context dict while adding a JSON-ready dump for templating

## Testing
- pytest tests/chain_executor -q *(fails: interrupted due to long-running dependency import)*

------
https://chatgpt.com/codex/tasks/task_e_68d8869eedb88330a7fa160eb10a74a8