### PR TITLE
Fix lint failures in patient context service and OpenAI adapter

### DIFF
--- a/services/patient_context/app.py
+++ b/services/patient_context/app.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated
-
-from fastapi import APIRouter, Depends, FastAPI, HTTPException, Path, Query, status
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Path, status
 
 from repositories.emr import EMRRepository
 from services.patient_context.mappers import map_patient_context, map_patient_record

--- a/shared/llm/adapters/openai.py
+++ b/shared/llm/adapters/openai.py
@@ -74,8 +74,7 @@ def get_chat_model(
 
     model_kwargs = filter_model_kwargs(ChatOpenAI, candidate_kwargs)
     model = ChatOpenAI(**model_kwargs)
-    return model
-    # model = ensure_langchain_compat(model)
+    model = ensure_langchain_compat(model)
     return attach_retry(
         model,
         label=f"openai/{model_name}",


### PR DESCRIPTION
## Summary
- remove unused FastAPI imports in the patient context service
- ensure the OpenAI adapter returns a retry-enabled model while keeping LangChain compatibility

## Testing
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68d88a29233483308b9f59921173bb26