### PR TITLE
Fix prompt metadata search and LangChain compatibility

### DIFF
--- a/services/prompt_catalog/repositories.py
+++ b/services/prompt_catalog/repositories.py
@@ -80,6 +80,16 @@ class PromptRepository:
             parts.append(prompt.description)
         if prompt.template:
             parts.append(prompt.template)
+        if prompt.metadata:
+            for value in prompt.metadata.values():
+                if value is None:
+                    continue
+                if isinstance(value, str):
+                    normalized = value
+                else:
+                    normalized = str(value)
+                if normalized:
+                    parts.append(normalized)
         haystack = " ".join(parts).lower()
         return query in haystack
 

--- a/shared/llm/adapters/_base.py
+++ b/shared/llm/adapters/_base.py
@@ -90,7 +90,7 @@ def ensure_langchain_compat(model: BaseLanguageModel) -> BaseLanguageModel:
         for candidate_name in candidates:
             candidate = getattr(model, candidate_name, None)
             if callable(candidate):
-                setattr(model, target, candidate)
+                object.__setattr__(model, target, candidate)
                 break
 
     _ensure_method("invoke", ("__call__", "predict", "generate"))

--- a/tests/prompt_catalog/test_repositories.py
+++ b/tests/prompt_catalog/test_repositories.py
@@ -15,7 +15,12 @@ def _create_repository() -> PromptRepository:
     return PromptRepository([prompt])
 
 
-@pytest.mark.asyncio
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
 async def test_search_prompts_negative_limit_returns_empty_list() -> None:
     repository = _create_repository()
 
@@ -24,7 +29,7 @@ async def test_search_prompts_negative_limit_returns_empty_list() -> None:
     assert results == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio("asyncio")
 async def test_search_prompts_zero_limit_returns_empty_list() -> None:
     repository = _create_repository()
 
@@ -33,7 +38,7 @@ async def test_search_prompts_zero_limit_returns_empty_list() -> None:
     assert results == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio("asyncio")
 async def test_get_prompt_accepts_string_identifier() -> None:
     repository = _create_repository()
 
@@ -43,7 +48,7 @@ async def test_get_prompt_accepts_string_identifier() -> None:
     assert result.key is ChatPromptKey.PATIENT_CONTEXT
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio("asyncio")
 async def test_get_prompt_accepts_enum_repr() -> None:
     repository = _create_repository()
 
@@ -53,7 +58,7 @@ async def test_get_prompt_accepts_enum_repr() -> None:
     assert result.key is ChatPromptKey.PATIENT_CONTEXT
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio("asyncio")
 async def test_prompt_identifier_skips_blank_metadata_id() -> None:
     prompt = ChatPrompt(
         title="Example Prompt",
@@ -67,3 +72,17 @@ async def test_prompt_identifier_skips_blank_metadata_id() -> None:
 
     assert empty_lookup is None
     assert title_lookup is prompt
+
+
+@pytest.mark.anyio("asyncio")
+async def test_search_prompts_matches_metadata_values() -> None:
+    prompt = ChatPrompt(
+        title="Example Prompt",
+        template="Hello",
+        metadata={"clinical_area": "Cardiology"},
+    )
+    repository = PromptRepository([prompt])
+
+    results = await repository.search_prompts(query="cardiology")
+
+    assert results == [prompt]

--- a/tests/shared/llm/test_retry_wrapping.py
+++ b/tests/shared/llm/test_retry_wrapping.py
@@ -271,6 +271,9 @@ def test_ensure_langchain_compat_replaces_stub_invoke():
         def __call__(self, value: str) -> str:
             return f"legacy {value}"
 
+
+    LegacyModel.__abstractmethods__ = frozenset()
+
     model = LegacyModel()
     patched = base_module.ensure_langchain_compat(model)
 
@@ -294,6 +297,9 @@ def test_ensure_langchain_compat_replaces_stub_ainvoke():
     class LegacyAsyncModel(base_module.BaseLanguageModel):
         async def apredict(self, value: str) -> str:
             return f"async {value}"
+
+
+    LegacyAsyncModel.__abstractmethods__ = frozenset()
 
     model = LegacyAsyncModel()
     patched = base_module.ensure_langchain_compat(model)


### PR DESCRIPTION
## Summary
- include prompt metadata values in repository search results and cover the case with a new async test
- allow ensure_langchain_compat to patch Pydantic-based models and update async/httpx tests for current dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d89895cdf08330a73f73014758ff1f