### PR TITLE
Escape braces in log formatter messages

### DIFF
--- a/shared/observability/logger.py
+++ b/shared/observability/logger.py
@@ -35,6 +35,13 @@ def _format_record(record: Mapping[str, Any]) -> str:
     service = extra.get("service", "-")
     request_id = extra.get("request_id") or extra.get("correlation_id") or "-"
     message = record.get("message", "")
+    if not isinstance(message, str):
+        message = str(message)
+    # ``loguru`` expects the return value to still be processed as a
+    # ``str.format`` template. Since our structured messages frequently
+    # contain JSON payloads, escape curly braces so that the formatter does
+    # not treat them as placeholders.
+    message = message.replace("{", "{{").replace("}", "}}")
     return f"{timestamp} | {level:<8} | {service} | {request_id} | {message}\n"
 
 


### PR DESCRIPTION
## Summary
- ensure loguru formatter escapes braces in messages so JSON payloads do not raise KeyError

## Testing
- pytest tests/shared/test_logger.py

------
https://chatgpt.com/codex/tasks/task_e_68d8c18ff1a48330a5711bc427703be3