### PR TITLE
Fix article usage in PromptEMRDataCategory docstring

### DIFF
--- a/shared/llm/chains/category_classifier.py
+++ b/shared/llm/chains/category_classifier.py
@@ -19,7 +19,7 @@ __all__ = [
 
 @dataclass(frozen=True)
 class PromptEMRDataCategory:
-    """Structured metadata for a EMR data category for a Prompt.
+    """Structured metadata for an EMR data category for a Prompt.
     Hints to the classifier about the EMR data required to answer the question.
     """
 


### PR DESCRIPTION
## Summary
- correct the article in the PromptEMRDataCategory docstring to read "an EMR"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8c19b445c8330942a5f3bf061b209