### PR TITLE
Clarify chain response inputs documentation

### DIFF
--- a/docs/openapi/chain_executor.json
+++ b/docs/openapi/chain_executor.json
@@ -328,7 +328,7 @@
           },
           "inputs": {
             "additionalProperties": true,
-            "description": "Initial variables supplied for the execution",
+            "description": "Final variable map after chain execution, including the initial inputs and any context or values derived during processing",
             "title": "Inputs",
             "type": "object"
           },

--- a/shared/models/chain.py
+++ b/shared/models/chain.py
@@ -105,7 +105,10 @@ class ChainExecutionResponse(CamelModel):
     )
     inputs: dict[str, Any] = Field(
         default_factory=dict,
-        description="Initial variables supplied for the execution",
+        description=(
+            "Final variable map after chain execution, including the initial "
+            "inputs and any context or values derived during processing"
+        ),
     )
     final_output_key: Optional[str] = Field(
         default=None, description="Identifier for the final step in the chain"


### PR DESCRIPTION
## Summary
- clarify that the ChainExecutionResponse.inputs field represents the final variable map including derived values
- update the OpenAPI schema description to match the new wording

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8c1b763148330a3480c7e9311ffc8