### PR TITLE
Add patient context client error handling tests

### DIFF
--- a/tests/chain_executor/test_patient_context_client.py
+++ b/tests/chain_executor/test_patient_context_client.py
@@ -5,7 +5,11 @@ from typing import cast
 import httpx
 import pytest
 
-from services.chain_executor.app import PatientContextClient
+from services.chain_executor.app import (
+    PatientContextClient,
+    PatientContextServiceError,
+    PatientNotFoundError,
+)
 
 
 @pytest.fixture
@@ -33,6 +37,27 @@ class _DummyHttpClient:
         return _DummyResponse({})
 
 
+class _NotFoundHttpClient:
+    def __init__(self) -> None:
+        self.requested_urls: list[str] = []
+
+    async def get(self, url: str) -> _DummyResponse:
+        self.requested_urls.append(url)
+        request = httpx.Request("GET", f"http://patient-context{url}")
+        response = httpx.Response(status_code=404, request=request)
+        raise httpx.HTTPStatusError("Not found", request=request, response=response)
+
+
+class _ErrorHttpClient:
+    def __init__(self, exc: httpx.HTTPError) -> None:
+        self._exc = exc
+        self.requested_urls: list[str] = []
+
+    async def get(self, url: str) -> _DummyResponse:
+        self.requested_urls.append(url)
+        raise self._exc
+
+
 @pytest.mark.anyio("asyncio")
 async def test_patient_context_client_strips_patient_identifier_whitespace() -> None:
     http_client = _DummyHttpClient()
@@ -42,3 +67,40 @@ async def test_patient_context_client_strips_patient_identifier_whitespace() -> 
     await client.get_patient_context("  patient-123  ")
 
     assert http_client.requested_urls == ["/patients/patient-123/context"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_patient_context_client_rejects_empty_patient_identifier() -> None:
+    http_client = _DummyHttpClient()
+    typed_client = cast(httpx.AsyncClient, http_client)
+    client = PatientContextClient(typed_client)
+
+    with pytest.raises(PatientContextServiceError, match="cannot be empty"):
+        await client.get_patient_context("   ")
+
+
+@pytest.mark.anyio("asyncio")
+async def test_patient_context_client_raises_not_found_for_missing_patient() -> None:
+    http_client = _NotFoundHttpClient()
+    typed_client = cast(httpx.AsyncClient, http_client)
+    client = PatientContextClient(typed_client)
+
+    with pytest.raises(PatientNotFoundError) as exc_info:
+        await client.get_patient_context("patient-404")
+
+    assert exc_info.value.patient_id == "patient-404"
+    assert http_client.requested_urls == ["/patients/patient-404/context"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_patient_context_client_wraps_generic_http_errors() -> None:
+    error = httpx.HTTPError("network down")
+    http_client = _ErrorHttpClient(error)
+    typed_client = cast(httpx.AsyncClient, http_client)
+    client = PatientContextClient(typed_client)
+
+    with pytest.raises(PatientContextServiceError) as exc_info:
+        await client.get_patient_context("patient-500")
+
+    assert exc_info.value.__cause__ is error
+    assert http_client.requested_urls == ["/patients/patient-500/context"]


### PR DESCRIPTION
## Summary
- add unit tests covering empty patient identifiers and HTTP error handling in the patient context client
- introduce lightweight HTTP client stubs to simulate 404 and generic network errors

## Testing
- PYTHONPATH=. pytest tests/chain_executor/test_patient_context_client.py

------
https://chatgpt.com/codex/tasks/task_e_68d8c1c154e08330854743095ad5a491