### PR TITLE
Format classifier prompt test with Ruff

### DIFF
--- a/tests/shared/llm/test_model_classifier.py
+++ b/tests/shared/llm/test_model_classifier.py
@@ -39,6 +39,5 @@ def test_classifier_prompt_injects_prompt_json() -> None:
     payload = {"example": "value"}
     rendered = classifier.chain.prompt.format(prompt_json=json.dumps(payload))
 
-    assert "\"example\": \"value\"" in rendered
+    assert '"example": "value"' in rendered
     assert "{prompt_json}" not in rendered
-


### PR DESCRIPTION
## Summary
- reformat `tests/shared/llm/test_model_classifier.py` using Ruff to satisfy CI formatting checks

## Testing
- `ruff format --check .`


------
https://chatgpt.com/codex/tasks/task_e_68d8c33e0a488330bb870b8e5be4ac91