### PR TITLE
Improve prompt category resolution and filtering

### DIFF
--- a/shared/models/chain.py
+++ b/shared/models/chain.py
@@ -47,6 +47,12 @@ class ChainExecutionRequest(CamelModel):
     patient_id: Optional[str] = Field(
         default=None, description="Optional patient identifier for context retrieval"
     )
+    categories: Optional[list[str]] = Field(
+        default=None,
+        description=(
+            "Optional EMR data categories to request from the patient context service"
+        ),
+    )
     variables: dict[str, Any] = Field(
         default_factory=dict,
         description="Initial variables supplied to the chain for template rendering",


### PR DESCRIPTION
## Summary
- prioritize prompt, request, and classifier category sources with validation against known slugs
- propagate sanitized categories to the patient context request and expose an optional categories field on chain execution requests
- update unit tests to cover category resolution paths and patient context filtering semantics

## Testing
- pytest tests/chain_executor/test_patient_context_client.py tests/chain_executor/test_execute_chain.py

------
https://chatgpt.com/codex/tasks/task_e_68d9220d684c833095d8db4f749d3f0d