### PR TITLE
Format chain executor modules with Ruff

### DIFF
--- a/services/chain_executor/app.py
+++ b/services/chain_executor/app.py
@@ -904,7 +904,9 @@ async def _build_execution_context(
     category_classifier: CategoryClassifier | None = None
     prompt_categories: list[str] = []
     if final_from_catalog:
-        prompt_categories = _filter_valid_categories(_get_prompt_categories(final_prompt))
+        prompt_categories = _filter_valid_categories(
+            _get_prompt_categories(final_prompt)
+        )
 
     final_categories: list[str] = []
     if prompt_categories:
@@ -917,7 +919,9 @@ async def _build_execution_context(
         category_classifier = await _ensure_prompt_categories(
             final_prompt, llm, category_classifier
         )
-        final_categories = _filter_valid_categories(_get_prompt_categories(final_prompt))
+        final_categories = _filter_valid_categories(
+            _get_prompt_categories(final_prompt)
+        )
 
     if payload.patient_id:
         try:

--- a/tests/chain_executor/test_execute_chain.py
+++ b/tests/chain_executor/test_execute_chain.py
@@ -221,9 +221,9 @@ class DummyClassifierInstance:
     ) -> None:
         self.chain = DummyClassifierChain(response_text=response_text)
         self.parse_calls: list[str] = []
-        self._parsed_result = list(parsed_result) if parsed_result is not None else [
-            "notes"
-        ]
+        self._parsed_result = (
+            list(parsed_result) if parsed_result is not None else ["notes"]
+        )
 
     def parse_response(self, text: str) -> list[str]:
         self.parse_calls.append(text)
@@ -580,7 +580,9 @@ async def test_execute_chain_requests_categories_from_classifier(
     response = result["response"]
     assert response.status_code == 200
 
-    assert result["create_calls"], "Classifier should be instantiated when categories missing"
+    assert result["create_calls"], (
+        "Classifier should be instantiated when categories missing"
+    )
 
     assert patient_client.calls == [
         {"patient_id": "patient-789", "categories": ["notes", "labs"]}

--- a/tests/chain_executor/test_patient_context_client.py
+++ b/tests/chain_executor/test_patient_context_client.py
@@ -70,9 +70,7 @@ async def test_patient_context_client_strips_patient_identifier_whitespace() -> 
     typed_client = cast(httpx.AsyncClient, http_client)
     client = PatientContextClient(typed_client)
 
-    await client.get_patient_context(
-        "  patient-123  ", categories=["labs", "notes"]
-    )
+    await client.get_patient_context("  patient-123  ", categories=["labs", "notes"])
 
     assert http_client.requests == [
         {


### PR DESCRIPTION
## Summary
- apply Ruff formatting updates to the chain executor service module
- reformat chain executor tests to satisfy Ruff style expectations

## Testing
- ruff format --check .

------
https://chatgpt.com/codex/tasks/task_e_68d92fcd086c83308cedfaa3719103e8