### PR TITLE
Add models discovery endpoint for chain executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ services:
   ```bash
   curl "http://localhost:8002/patients/123456/context" | jq
   ```
+* Discover available LLM providers and metadata from the chain executor service:
+  ```bash
+  curl http://localhost:8003/chains/models | jq
+  ```
 * Execute a two-step chain that pulls patient context and drafts a clinical plan:
   ```bash
   curl -X POST http://localhost:8003/chains/execute \

--- a/docs/openapi/chain_executor.json
+++ b/docs/openapi/chain_executor.json
@@ -2015,6 +2015,96 @@
         },
         "title": "VitalSign",
         "type": "object"
+      },
+      "ChainExecutorModelSpec": {
+        "description": "Serialized representation of a model specification.",
+        "properties": {
+          "aliases": {
+            "default": [],
+            "description": "Ordered list of accepted aliases for the model.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Aliases",
+            "type": "array"
+          },
+          "canonical_name": {
+            "description": "Canonical model name for the provider configuration.",
+            "title": "Canonical Name",
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Human readable model description.",
+            "title": "Description"
+          },
+          "provider": {
+            "description": "Canonical provider identifier value.",
+            "title": "Provider",
+            "type": "string"
+          }
+        },
+        "required": [
+          "provider",
+          "canonical_name"
+        ],
+        "title": "ChainExecutorModelSpec",
+        "type": "object"
+      },
+      "ChainExecutorModelsResponse": {
+        "description": "Response payload returned by the models discovery endpoint.",
+        "properties": {
+          "models": {
+            "items": {
+              "$ref": "#/components/schemas/ChainExecutorModelSpec"
+            },
+            "title": "Models",
+            "type": "array"
+          },
+          "service": {
+            "$ref": "#/components/schemas/ChainExecutorServiceMetadata"
+          }
+        },
+        "required": [
+          "service",
+          "models"
+        ],
+        "title": "ChainExecutorModelsResponse",
+        "type": "object"
+      },
+      "ChainExecutorServiceMetadata": {
+        "description": "Describes metadata for the chain executor service.",
+        "properties": {
+          "default_model_name": {
+            "description": "Configured default provider-specific model name.",
+            "title": "Default Model Name",
+            "type": "string"
+          },
+          "default_model_provider": {
+            "description": "Configured default model provider identifier.",
+            "title": "Default Model Provider",
+            "type": "string"
+          },
+          "name": {
+            "description": "Logical name of the service.",
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "default_model_provider",
+          "default_model_name"
+        ],
+        "title": "ChainExecutorServiceMetadata",
+        "type": "object"
       }
     }
   },
@@ -2024,6 +2114,38 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/chains/models": {
+      "get": {
+        "description": "Return metadata for available language model providers.",
+        "operationId": "list_models_chains_models_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChainExecutorModelsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Models",
+        "tags": [
+          "chains"
+        ]
+      }
+    },
     "/chains/execute": {
       "post": {
         "description": "Execute a sequence of prompts using the configured language model provider.",

--- a/services/chain_executor/app.py
+++ b/services/chain_executor/app.py
@@ -16,7 +16,7 @@ from fastapi.responses import StreamingResponse
 from langchain.chains import LLMChain
 from langchain.prompts import PromptTemplate
 from langchain_core.messages import AIMessage, AIMessageChunk
-from pydantic import AnyHttpUrl, Field
+from pydantic import AnyHttpUrl, BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from shared.config.settings import Settings, get_settings
@@ -32,6 +32,7 @@ from shared.llm import (
     resolve_model_spec,
     resolve_provider,
 )
+from shared.llm.llmmodels import get_all_model_specs
 from shared.llm.providers import LLMProvider
 from shared.llm.chains import (
     CategoryClassifier,
@@ -107,6 +108,41 @@ def get_service_settings() -> ChainExecutorSettings:
 
 _prompt_http_client: httpx.AsyncClient | None = None
 _context_http_client: httpx.AsyncClient | None = None
+
+
+class ChainExecutorServiceMetadata(BaseModel):
+    """Describes metadata for the chain executor service."""
+
+    name: str = Field(..., description="Logical name of the service.")
+    default_model_provider: str = Field(
+        ..., description="Configured default model provider identifier."
+    )
+    default_model_name: str = Field(
+        ..., description="Configured default provider-specific model name."
+    )
+
+
+class ChainExecutorModelSpec(BaseModel):
+    """Serialized representation of a model specification."""
+
+    provider: str = Field(..., description="Canonical provider identifier value.")
+    canonical_name: str = Field(
+        ..., description="Canonical model name for the provider configuration."
+    )
+    aliases: list[str] = Field(
+        default_factory=list,
+        description="Ordered list of accepted aliases for the model.",
+    )
+    description: str | None = Field(
+        default=None, description="Human readable model description."
+    )
+
+
+class ChainExecutorModelsResponse(BaseModel):
+    """Response payload returned by the models discovery endpoint."""
+
+    service: ChainExecutorServiceMetadata
+    models: list[ChainExecutorModelSpec]
 
 
 def _strip_trailing_slash(url: str) -> str:
@@ -1167,6 +1203,34 @@ async def _execute_chain_streaming(
     return iterator()
 
 
+@router.get(
+    "/models",
+    response_model=ChainExecutorModelsResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def list_models(
+    settings: Settings = Depends(get_settings),
+) -> ChainExecutorModelsResponse:
+    """Return metadata for available language model providers."""
+
+    specs = get_all_model_specs()
+    metadata = ChainExecutorServiceMetadata(
+        name=SERVICE_NAME,
+        default_model_provider=settings.default_model.provider,
+        default_model_name=settings.default_model.name,
+    )
+    models = [
+        ChainExecutorModelSpec(
+            provider=spec.provider.value,
+            canonical_name=spec.canonical_name,
+            aliases=list(spec.aliases),
+            description=spec.description,
+        )
+        for spec in specs
+    ]
+    return ChainExecutorModelsResponse(service=metadata, models=models)
+
+
 @router.post(
     "/execute",
     response_model=ChainExecutionResponse,
@@ -1215,4 +1279,11 @@ def get_app() -> FastAPI:
     return app
 
 
-__all__ = ["app", "get_app", "health", "execute_chain", "stream_chain_execution"]
+__all__ = [
+    "app",
+    "get_app",
+    "health",
+    "list_models",
+    "execute_chain",
+    "stream_chain_execution",
+]

--- a/shared/llm/llmmodels.py
+++ b/shared/llm/llmmodels.py
@@ -261,6 +261,12 @@ def available_model_specs() -> Tuple[ModelSpec, ...]:
     return tuple(_MODEL_SPECS.values())
 
 
+def get_all_model_specs() -> Tuple[ModelSpec, ...]:
+    """Return all registered model specifications."""
+
+    return available_model_specs()
+
+
 def get_model_spec(provider: LLMProvider) -> ModelSpec:
     """Return the canonical :class:`ModelSpec` for ``provider``."""
 
@@ -386,6 +392,7 @@ __all__ = [
     "DEFAULT_MODEL_PROVIDER",
     "DEFAULT_CANONICAL_MODEL_NAME",
     "available_model_specs",
+    "get_all_model_specs",
     "canonical_model_name",
     "get_model_spec",
     "resolve_model_name",

--- a/tests/chain_executor/test_models_endpoint.py
+++ b/tests/chain_executor/test_models_endpoint.py
@@ -1,0 +1,72 @@
+import sys
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Ensure anyio-powered tests execute against the asyncio backend."""
+
+    return "asyncio"
+
+
+async def _request_models_payload() -> dict:
+    from services.chain_executor import app as chain_app
+
+    transport = ASGITransport(app=chain_app.app)
+    try:
+        async with AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            response = await client.get("/chains/models")
+    finally:
+        await transport.aclose()
+
+    assert response.status_code == 200
+    return response.json()
+
+
+@pytest.mark.anyio
+async def test_models_endpoint_returns_all_specs() -> None:
+    from services.chain_executor import app as chain_app
+    from shared.llm.llmmodels import get_all_model_specs
+
+    payload = await _request_models_payload()
+
+    specs = get_all_model_specs()
+    models = {entry["provider"]: entry for entry in payload["models"]}
+
+    assert set(models) == {spec.provider.value for spec in specs}
+
+    for spec in specs:
+        entry = models[spec.provider.value]
+        assert entry["canonical_name"] == spec.canonical_name
+        assert entry["description"] == spec.description
+
+    service = payload["service"]
+    settings = chain_app.get_settings()
+
+    assert service["name"] == chain_app.SERVICE_NAME
+    assert service["default_model_provider"] == settings.default_model.provider
+    assert service["default_model_name"] == settings.default_model.name
+
+
+@pytest.mark.anyio
+async def test_models_endpoint_preserves_alias_ordering() -> None:
+    from shared.llm.llmmodels import get_all_model_specs
+
+    payload = await _request_models_payload()
+
+    models = {entry["provider"]: entry for entry in payload["models"]}
+
+    for spec in get_all_model_specs():
+        aliases = models[spec.provider.value]["aliases"]
+        assert aliases == list(spec.aliases)
+        if aliases:
+            assert aliases[0] == spec.aliases[0]


### PR DESCRIPTION
## Summary
- add a `/chains/models` endpoint that surfaces serialized model metadata with service defaults
- expose a `get_all_model_specs` helper for sharing the registered model catalog
- document the discovery API and add integration coverage for alias ordering

## Testing
- pytest tests/chain_executor/test_models_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68d98c243b3083308838e737e719bbc2