### PR TITLE
Expand prompt catalog with categorized templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ can be imported into tooling such as Postman or Stoplight. See
 [`docs/architecture.md`](docs/architecture.md) for a deeper dive into the orchestration
 strategy, provider selection, and prompt categorisation logic.
 
+## Bundled prompt catalog
+
+The prompt catalog service ships with reusable templates that cover common
+clinical workflows. Each prompt includes category labels so downstream services
+can request the right slices of patient context.
+
+| Key | Title | Description | Categories |
+| --- | --- | --- | --- |
+| `patient_context` | Patient Context Overview | Summarise clinical background and social determinants for the visit. | patientDetail, problems, socialHistory, careTeam |
+| `clinical_plan` | Clinical Plan Outline | Draft a multi-domain assessment and plan from encounter details. | problems, orders, medications, labs, testResults |
+| `follow_up_questions` | Follow-up Question Suggestions | Propose clarifying follow-up questions based on open issues. | notes, problems, patientDetail |
+| `patient_summary` | Comprehensive Patient Summary | Combine demographics, active problems, and recent findings into a cohesive narrative. | patientDetail, problems, notes |
+| `differential_diagnosis` | Differential Diagnosis Explorer | Prioritise differentials with supporting evidence and recommended workup. | problems, labs, testResults, notes |
+| `patient_education` | Patient Education Brief | Translate the care plan into accessible counselling points and safety advice. | medications, carePlans, socialHistory |
+| `safety_checks` | Care Safety Checklist | Flag medication, allergy, and monitoring concerns requiring action. | medications, allergies, vitals, orders |
+| `triage_assessment` | Urgency Triage Assessment | Evaluate visit urgency from presenting symptoms, vitals, and risk factors. | vitals, patientDetail, riskScores, encounters |
+
 ## Environment setup
 
 ### Configure environment variables

--- a/services/prompt_catalog/repositories.py
+++ b/services/prompt_catalog/repositories.py
@@ -155,6 +155,7 @@ _DEFAULT_PROMPTS: tuple[ChatPrompt, ...] = (
             "recent events, and any notable social determinants of health."
         ),
         input_variables=["patient_background"],
+        categories=["patientDetail", "problems", "socialHistory", "careTeam"],
     ),
     ChatPrompt(
         key=ChatPromptKey.CLINICAL_PLAN,
@@ -165,6 +166,7 @@ _DEFAULT_PROMPTS: tuple[ChatPrompt, ...] = (
             "plan addressing differential diagnoses, recommended studies, and follow-up."
         ),
         input_variables=["encounter_overview"],
+        categories=["problems", "orders", "medications", "labs", "testResults"],
     ),
     ChatPrompt(
         key=ChatPromptKey.FOLLOW_UP_QUESTIONS,
@@ -175,6 +177,68 @@ _DEFAULT_PROMPTS: tuple[ChatPrompt, ...] = (
             "questions to explore unresolved issues and safety concerns."
         ),
         input_variables=["patient_summary"],
+        categories=["notes", "problems", "patientDetail"],
+    ),
+    ChatPrompt(
+        key=ChatPromptKey.PATIENT_SUMMARY,
+        title="Comprehensive Patient Summary",
+        description="Produce an integrated narrative that blends demographics, history, and active concerns.",
+        template=(
+            "Integrate the structured details below into a cohesive patient summary. "
+            "Demographics: {demographics}. Active problems: {active_problems}. "
+            "Recent clinical highlights: {clinical_highlights}. Focus on trends and "
+            "clinical relevance for the current encounter."
+        ),
+        input_variables=["demographics", "active_problems", "clinical_highlights"],
+        categories=["patientDetail", "problems", "notes"],
+    ),
+    ChatPrompt(
+        key=ChatPromptKey.DIFFERENTIAL_DIAGNOSIS,
+        title="Differential Diagnosis Explorer",
+        description="Outline prioritized differential diagnoses with supporting evidence and next steps.",
+        template=(
+            "Given the chief concern {chief_complaint} and key findings {clinical_findings}, "
+            "list the top differential diagnoses. For each, summarise supporting/contradicting "
+            "data and note recommended diagnostics to confirm or exclude the condition."
+        ),
+        input_variables=["chief_complaint", "clinical_findings"],
+        categories=["problems", "labs", "testResults", "notes"],
+    ),
+    ChatPrompt(
+        key=ChatPromptKey.PATIENT_EDUCATION,
+        title="Patient Education Brief",
+        description="Draft plain-language counseling points tailored to the patient's condition and treatments.",
+        template=(
+            "Using the treatment plan {treatment_plan} and patient considerations {patient_considerations}, "
+            "create education points that explain the condition, medications, lifestyle adjustments, "
+            "and follow-up needs in accessible language. Highlight safety precautions and when to seek care."
+        ),
+        input_variables=["treatment_plan", "patient_considerations"],
+        categories=["medications", "carePlans", "socialHistory"],
+    ),
+    ChatPrompt(
+        key=ChatPromptKey.SAFETY_CHECKS,
+        title="Care Safety Checklist",
+        description="Review high-risk medications, allergies, and monitoring requirements for safety.",
+        template=(
+            "Review the active medication list {active_medications}, allergy history {allergy_history}, "
+            "and recent vitals {recent_vitals}. Summarize potential safety concerns such as interactions, "
+            "contraindications, or monitoring gaps, and recommend mitigation steps."
+        ),
+        input_variables=["active_medications", "allergy_history", "recent_vitals"],
+        categories=["medications", "allergies", "vitals", "orders"],
+    ),
+    ChatPrompt(
+        key=ChatPromptKey.TRIAGE_ASSESSMENT,
+        title="Urgency Triage Assessment",
+        description="Assess visit urgency based on presenting symptoms, vitals, and risk factors.",
+        template=(
+            "Given the presenting symptoms {presenting_symptoms}, vital trends {triage_vitals}, "
+            "and notable risk factors {risk_factors}, determine the appropriate triage level. "
+            "Justify the recommendation with specific findings and suggest immediate interventions if needed."
+        ),
+        input_variables=["presenting_symptoms", "triage_vitals", "risk_factors"],
+        categories=["vitals", "patientDetail", "riskScores", "encounters"],
     ),
 )
 


### PR DESCRIPTION
## Summary
- add category-aware defaults for existing prompts and append new templates covering summary, differential, education, safety, and triage flows
- extend prompt repository tests to validate the expanded catalog and ensure each prompt can be fetched by key
- document the bundled prompts and their categories in the README for quick discovery

## Testing
- PYTHONPATH=. pytest tests/prompt_catalog/test_repositories.py

------
https://chatgpt.com/codex/tasks/task_e_68d992937fc483308267c7b0a823c617