### PR TITLE
Add API gateway entrypoint and smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ can request the right slices of patient context.
    uvicorn services.prompt_catalog.app:app --reload --port 8001
    uvicorn services.patient_context.app:app --reload --port 8002
    uvicorn services.chain_executor.app:app --reload --port 8003
-   uvicorn services.api_gateway.app:app --reload --port 8000
+   uvicorn services.api_gateway.main:app --reload --port 8000
    ```
 
 ### Option B: Docker Compose stack

--- a/services/api_gateway/main.py
+++ b/services/api_gateway/main.py
@@ -2,21 +2,18 @@
 
 from __future__ import annotations
 
+import uvicorn
 from fastapi import FastAPI
 
-from .app import app, get_app as _get_app
+from .app import get_app
 
-__all__ = ["app", "get_app"]
+app: FastAPI = get_app()
 
-
-def get_app() -> FastAPI:
-    """Return the configured FastAPI application."""
-
-    return _get_app()
+__all__ = ["app", "get_app", "main"]
 
 
-if __name__ == "__main__":  # pragma: no cover
-    import uvicorn
+def main() -> None:
+    """Run the API gateway using ``uvicorn``."""
 
     uvicorn.run(
         "services.api_gateway.main:app",
@@ -24,3 +21,7 @@ if __name__ == "__main__":  # pragma: no cover
         port=8000,
         reload=True,
     )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/api_gateway/test_import.py
+++ b/tests/api_gateway/test_import.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from services.api_gateway.app import get_app
+
+
+def test_get_app_returns_fastapi_instance() -> None:
+    app = get_app()
+
+    assert isinstance(app, FastAPI)


### PR DESCRIPTION
## Summary
- expose the API gateway FastAPI app through a dedicated main module with a uvicorn helper
- update documentation to reference the new module path
- add a smoke test validating the gateway app can be imported

## Testing
- pytest tests/api_gateway/test_import.py

------
https://chatgpt.com/codex/tasks/task_e_68d99f6f24988330891bf6c0189d0760