### PR TITLE
Add Dockerfile for anonymizer service

### DIFF
--- a/services/anonymizer/Dockerfile
+++ b/services/anonymizer/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.5
+
+ARG BASE_IMAGE=ai-chat-ehr-base:latest
+FROM ${BASE_IMAGE} AS runtime
+
+WORKDIR /app
+
+# Copy project metadata and source required for installation
+COPY pyproject.toml README.md ./
+COPY shared ./shared
+COPY repositories ./repositories
+COPY services/__init__.py ./services/__init__.py
+COPY services/anonymizer ./services/anonymizer
+
+# Install the application package to ensure dependencies are available
+RUN pip install --no-cache-dir .
+
+EXPOSE 8004
+
+CMD ["uvicorn", "services.anonymizer.main:app", "--host", "0.0.0.0", "--port", "8004"]


### PR DESCRIPTION
## Summary
- add a Dockerfile for the anonymizer service that extends the shared base image
- install the project package, copy required sources, and expose the service port
- configure the container to launch the anonymizer API with Uvicorn

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc4fc1bd70833091e85809c3ba5af4