### PR TITLE
Add Presidio engine configuration and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,9 @@ dependencies = [
     "anthropic>=0.67,<1",
     "loguru>=0.7,<0.8",
     "structlog>=24.1,<25",
-    "tenacity>=8.2,<9"
+    "tenacity>=8.2,<9",
+    # Presidio analyzer provides deterministic PII detection used by the anonymizer
+    "presidio-analyzer>=2.2,<3",
 ]
 
 [project.optional-dependencies]

--- a/services/anonymizer/app/anonymization/presidio_engine.py
+++ b/services/anonymizer/app/anonymization/presidio_engine.py
@@ -1,0 +1,115 @@
+"""Utilities for configuring Microsoft Presidio analyzers.
+
+This module centralizes construction of the :class:`~presidio_analyzer.AnalyzerEngine`
+used by the anonymizer service.  We start from Presidio's built-in recognizers and
+extend them with domain specific ones for facility names and insurance member IDs.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Optional, Sequence
+
+from presidio_analyzer import AnalyzerEngine, Pattern, PatternRecognizer
+from presidio_analyzer.nlp_engine import NlpEngine
+from presidio_analyzer.recognizer_registry import RecognizerRegistry
+
+__all__ = [
+    "build_analyzer_engine",
+    "build_registry",
+]
+
+# Facility names follow predictable suffixes (Hospital, Clinic, Medical Center, etc.)
+# The regex looks for a capitalized word optionally preceded by "St." and followed
+# by one of these suffixes.  Context words reinforce that these spans correspond to
+# healthcare facilities.
+_FACILITY_PATTERNS: Sequence[Pattern] = (
+    Pattern(
+        name="facility_suffix",
+        regex=r"\b(?:St\.?\s)?[A-Z][\w'&.-]{1,40}\s(?:Hospital|Clinic|Medical Center|Health Center|Urgent Care|Medical Group)\b",
+        score=0.7,
+    ),
+)
+_FACILITY_CONTEXT = ["hospital", "clinic", "medical", "center", "facility", "care"]
+
+# Member identifiers typically mix uppercase letters and digits and appear alongside
+# key phrases such as "member ID" or "subscriber number".  The regex avoids matching
+# very short sequences to reduce false positives.
+_MEMBER_ID_PATTERNS: Sequence[Pattern] = (
+    Pattern(
+        name="member_id_alphanumeric",
+        regex=r"\b[A-Z]{2,5}[0-9]{4,10}\b",
+        score=0.5,
+    ),
+    Pattern(
+        name="member_id_mixed",
+        regex=r"\b[0-9]{2,4}[A-Z]{2,5}[0-9]{2,6}\b",
+        score=0.5,
+    ),
+)
+_MEMBER_ID_CONTEXT = [
+    "member",
+    "subscriber",
+    "policy",
+    "plan",
+    "beneficiary",
+    "id",
+    "number",
+]
+
+
+def _build_facility_name_recognizer() -> PatternRecognizer:
+    """Return a recognizer for hospital and clinic names."""
+
+    return PatternRecognizer(
+        supported_entity="FACILITY_NAME",
+        name="FacilityNameRecognizer",
+        patterns=list(_FACILITY_PATTERNS),
+        context=list(_FACILITY_CONTEXT),
+    )
+
+
+def _build_member_id_recognizer() -> PatternRecognizer:
+    """Return a recognizer for insurance member identifiers."""
+
+    return PatternRecognizer(
+        supported_entity="MEMBER_ID",
+        name="MemberIdRecognizer",
+        patterns=list(_MEMBER_ID_PATTERNS),
+        context=list(_MEMBER_ID_CONTEXT),
+    )
+
+
+def build_registry(additional_recognizers: Optional[Iterable[PatternRecognizer]] = None) -> RecognizerRegistry:
+    """Create a :class:`RecognizerRegistry` with Presidio defaults and custom ones."""
+
+    registry = RecognizerRegistry()
+    registry.load_predefined_recognizers()
+
+    for recognizer in (_build_facility_name_recognizer(), _build_member_id_recognizer()):
+        registry.add_recognizer(recognizer)
+
+    if additional_recognizers:
+        for recognizer in additional_recognizers:
+            registry.add_recognizer(recognizer)
+
+    return registry
+
+
+def build_analyzer_engine(
+    *,
+    nlp_engine: Optional[NlpEngine] = None,
+    recognizers: Optional[Iterable[PatternRecognizer]] = None,
+) -> AnalyzerEngine:
+    """Construct an :class:`AnalyzerEngine` preloaded with recognizers.
+
+    Parameters
+    ----------
+    nlp_engine:
+        Optional Presidio NLP engine.  Tests may provide lightweight stubs to avoid
+        loading heavyweight spaCy or Stanza models.  When ``None`` Presidio will
+        lazily create an engine based on its default configuration.
+    recognizers:
+        Optional additional recognizers to register alongside the built-ins.
+    """
+
+    registry = build_registry(additional_recognizers=recognizers)
+    return AnalyzerEngine(registry=registry, nlp_engine=nlp_engine)

--- a/services/anonymizer/tests/test_presidio_engine.py
+++ b/services/anonymizer/tests/test_presidio_engine.py
@@ -1,0 +1,54 @@
+import re
+
+import pytest
+
+pytest.importorskip("presidio_analyzer")
+
+from presidio_analyzer import AnalyzerEngine, PatternRecognizer
+
+from services.anonymizer.app.anonymization.presidio_engine import build_analyzer_engine, build_registry
+
+
+@pytest.fixture()
+def registry():
+    return build_registry()
+
+
+def test_registry_includes_predefined_person_recognizer(registry):
+    recognizers = registry.get_recognizers(language="en", entities=["PERSON"])
+    assert recognizers, "Expected default PERSON recognizer to be available"
+
+
+def test_facility_name_recognizer_registered(registry):
+    recognizers = [
+        r
+        for r in registry.get_recognizers(language="en")
+        if isinstance(r, PatternRecognizer) and "FACILITY_NAME" in r.supported_entities
+    ]
+    assert recognizers, "Facility name recognizer should be registered"
+    facility_recognizer = recognizers[0]
+    pattern_regexes = [pattern.regex for pattern in facility_recognizer.patterns]
+    assert any("Hospital" in regex for regex in pattern_regexes)
+    for regex in pattern_regexes:
+        compiled = re.compile(regex)
+        assert compiled.search("St. Mary Medical Center")
+
+
+def test_member_id_recognizer_registered(registry):
+    recognizers = [
+        r
+        for r in registry.get_recognizers(language="en")
+        if isinstance(r, PatternRecognizer) and "MEMBER_ID" in r.supported_entities
+    ]
+    assert recognizers, "Member ID recognizer should be registered"
+    member_recognizer = recognizers[0]
+    pattern_regexes = [pattern.regex for pattern in member_recognizer.patterns]
+    assert any(re.search(regex, "Plan ID: AB12345678") for regex in pattern_regexes)
+
+
+def test_build_analyzer_engine_uses_registry(registry):
+    engine = build_analyzer_engine(nlp_engine=None)
+    assert isinstance(engine, AnalyzerEngine)
+    # AnalyzerEngine keeps a reference to the registry, so the custom recognizers should be present.
+    recognizers = engine.registry.get_recognizers(language="en", entities=["FACILITY_NAME"])
+    assert recognizers, "Analyzer engine should expose the custom facility recognizer"


### PR DESCRIPTION
## Summary
- add a Presidio analyzer engine factory that registers built-in and custom recognizers for facility names and member IDs
- include unit tests to ensure the custom recognizers are available and that the analyzer can be constructed
- declare presidio-analyzer as a core dependency for the anonymizer service

## Testing
- pytest services/anonymizer/tests/test_presidio_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68dc58041dd88330a38609a73df9a410