### PR TITLE
Add patient anonymization endpoint and pipeline summary

### DIFF
--- a/services/anonymizer/app/config/settings.py
+++ b/services/anonymizer/app/config/settings.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from pathlib import Path
+from typing import Any, Sequence
 
 from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_DEFAULT_DDL_DIRECTORY = (
+    Path(__file__).resolve().parents[1] / "pipelines" / "ddl"
+).resolve()
 
 
 class AppSettings(BaseSettings):
@@ -59,12 +65,104 @@ class LoggingSettings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 
+class FirestoreSettings(BaseSettings):
+    """Firestore client configuration."""
+
+    project_id: str | None = Field(
+        default=None,
+        description="Google Cloud project identifier for Firestore.",
+        validation_alias=AliasChoices(
+            "ANONYMIZER_FIRESTORE_PROJECT_ID", "FIRESTORE_PROJECT_ID"
+        ),
+    )
+    default_collection: str | None = Field(
+        default="patients",
+        description="Default collection used when fetching patient documents.",
+        validation_alias=AliasChoices(
+            "ANONYMIZER_FIRESTORE_COLLECTION", "FIRESTORE_COLLECTION"
+        ),
+    )
+    credentials_path: str | None = Field(
+        default=None,
+        description="Filesystem path to a service account JSON credential.",
+        validation_alias=AliasChoices(
+            "ANONYMIZER_FIRESTORE_CREDENTIALS_PATH",
+            "FIRESTORE_CREDENTIALS_PATH",
+        ),
+    )
+    credentials_info: dict[str, Any] | None = Field(
+        default=None,
+        description="Dictionary of credential information for Firestore clients.",
+        validation_alias=AliasChoices(
+            "ANONYMIZER_FIRESTORE_CREDENTIALS_INFO",
+            "FIRESTORE_CREDENTIALS_INFO",
+        ),
+    )
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+
+class PipelineSettings(BaseSettings):
+    """Configuration driving anonymization pipeline behaviour."""
+
+    ddl_directory: str = Field(
+        default=str(_DEFAULT_DDL_DIRECTORY),
+        description="Directory containing .ddl files for pipeline mappings.",
+        validation_alias=AliasChoices(
+            "ANONYMIZER_PIPELINE_DDL_DIRECTORY", "PIPELINE_DDL_DIRECTORY"
+        ),
+    )
+    include_defaulted: bool = Field(
+        default=False,
+        description="Include columns with defaults when building INSERT statements.",
+        validation_alias=AliasChoices(
+            "ANONYMIZER_PIPELINE_INCLUDE_DEFAULTED",
+            "PIPELINE_INCLUDE_DEFAULTED",
+        ),
+    )
+    include_nullable: bool = Field(
+        default=True,
+        description="Include nullable columns when building INSERT statements.",
+        validation_alias=AliasChoices(
+            "ANONYMIZER_PIPELINE_INCLUDE_NULLABLE",
+            "PIPELINE_INCLUDE_NULLABLE",
+        ),
+    )
+    returning: dict[str, Sequence[str]] = Field(
+        default_factory=dict,
+        description="Mapping of DDL keys to RETURNING clause column names.",
+        validation_alias=AliasChoices(
+            "ANONYMIZER_PIPELINE_RETURNING", "PIPELINE_RETURNING"
+        ),
+    )
+    patient_collection: str | None = Field(
+        default="patients",
+        description="Firestore collection storing patient documents.",
+        validation_alias=AliasChoices(
+            "ANONYMIZER_PIPELINE_PATIENT_COLLECTION",
+            "PIPELINE_PATIENT_COLLECTION",
+        ),
+    )
+    patient_ddl_key: str = Field(
+        default="patients",
+        description="DDL mapping key used for patient anonymization inserts.",
+        validation_alias=AliasChoices(
+            "ANONYMIZER_PIPELINE_PATIENT_DDL_KEY",
+            "PIPELINE_PATIENT_DDL_KEY",
+        ),
+    )
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+
 class Settings(BaseSettings):
     """Aggregated settings namespace for the anonymizer service."""
 
     app: AppSettings = Field(default_factory=AppSettings)
     database: DatabaseSettings = Field(default_factory=DatabaseSettings)
     logging: LoggingSettings = Field(default_factory=LoggingSettings)
+    firestore: FirestoreSettings = Field(default_factory=FirestoreSettings)
+    pipeline: PipelineSettings = Field(default_factory=PipelineSettings)
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -84,6 +182,8 @@ __all__ = [
     "AppSettings",
     "DatabaseSettings",
     "LoggingSettings",
+    "PipelineSettings",
+    "FirestoreSettings",
     "Settings",
     "get_settings",
 ]

--- a/services/anonymizer/app/pipelines/ddl/patients.ddl
+++ b/services/anonymizer/app/pipelines/ddl/patients.ddl
@@ -1,0 +1,5 @@
+CREATE TABLE anonymized_patients (
+    document_id TEXT PRIMARY KEY,
+    anonymized_payload JSONB NOT NULL,
+    processed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/services/anonymizer/tests/test_main.py
+++ b/services/anonymizer/tests/test_main.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import HTTPException
+
+from services.anonymizer.app.main import create_app
+from services.anonymizer.app.pipelines.patient_pipeline import (
+    PatientDocumentNotFoundError,
+    PipelineRunSummary,
+    ReplacementSummary,
+)
+from services.anonymizer.app.config import get_settings
+
+
+def _get_anonymize_endpoint(app):
+    for route in app.routes:
+        if getattr(route, "path", None) == "/anonymize/patients/{document_id}":
+            return route.endpoint
+    raise AssertionError("Anonymize route not registered")
+
+
+@pytest.mark.anyio
+async def test_anonymize_patient_returns_summary() -> None:
+    app = create_app()
+    handler = _get_anonymize_endpoint(app)
+
+    summary = PipelineRunSummary(
+        document_id="doc-123",
+        collection="patients",
+        anonymized_patient={"foo": "bar"},
+        replacements=(ReplacementSummary(entity_type="PERSON", count=2),),
+        repository_results=({"id": 1},),
+    )
+
+    class StubPipeline:
+        async def run_with_summary(self, document_id: str, *, collection: str | None = None) -> PipelineRunSummary:  # noqa: D401 - simple stub
+            assert document_id == "doc-123"
+            assert collection == "patients"
+            return summary
+
+    result = await handler(
+        document_id="doc-123",
+        pipeline=StubPipeline(),
+        settings=get_settings(),
+    )
+
+    payload = result
+    assert payload["documentId"] == "doc-123"
+    assert payload["collection"] == "patients"
+    assert payload["anonymizedPatient"] == {"foo": "bar"}
+    assert payload["anonymization"] == {
+        "totalReplacements": 2,
+        "entities": [{"entityType": "PERSON", "count": 2}],
+    }
+    assert payload["repository"] == {
+        "rows": [{"id": 1}],
+        "count": 1,
+    }
+
+
+@pytest.mark.anyio
+async def test_anonymize_patient_handles_missing_document() -> None:
+    app = create_app()
+    handler = _get_anonymize_endpoint(app)
+
+    class MissingPipeline:
+        async def run_with_summary(self, document_id: str, *, collection: str | None = None) -> PipelineRunSummary:  # noqa: D401 - simple stub
+            raise PatientDocumentNotFoundError(document_id)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await handler(
+            document_id="unknown",
+            pipeline=MissingPipeline(),
+            settings=get_settings(),
+        )
+
+    error = excinfo.value
+    assert error.status_code == 404
+    assert error.detail == {
+        "message": "Patient document 'unknown' was not found in Firestore.",
+        "documentId": "unknown",
+    }
+
+
+@pytest.mark.anyio
+async def test_anonymize_patient_handles_unexpected_error() -> None:
+    app = create_app()
+    handler = _get_anonymize_endpoint(app)
+
+    class FailingPipeline:
+        async def run_with_summary(self, document_id: str, *, collection: str | None = None) -> PipelineRunSummary:  # noqa: D401 - simple stub
+            raise RuntimeError("boom")
+
+    with pytest.raises(HTTPException) as excinfo:
+        await handler(
+            document_id="doc-123",
+            pipeline=FailingPipeline(),
+            settings=get_settings(),
+        )
+
+    error = excinfo.value
+    assert error.status_code == 500
+    assert error.detail == "Failed to anonymize patient document."


### PR DESCRIPTION
## Summary
- extend the anonymizer FastAPI app with a `POST /anonymize/patients/{document_id}` route that runs the patient pipeline and returns anonymization metadata
- add Firestore/pipeline configuration helpers, a default patients DDL mapping, and cacheable clients for Firestore and PostgreSQL
- enhance the patient pipeline to produce run summaries and cover the endpoint behaviour with async tests

## Testing
- `pytest services/anonymizer/tests/test_main.py` *(skipped: FastAPI dependency unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5bbdacf08330a66bd57265be272f