### PR TITLE
Add Tenacity retries and graceful degradation to patient pipeline

### DIFF
--- a/services/anonymizer/app/pipelines/resilience.py
+++ b/services/anonymizer/app/pipelines/resilience.py
@@ -1,0 +1,105 @@
+"""Resilience helpers for anonymizer pipelines.
+
+Provides reusable retry orchestration primitives powered by Tenacity so that
+pipeline components can make outbound calls with consistent backoff policies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Iterable, TypeVar
+
+from tenacity import (  # type: ignore[import-not-found]
+    AsyncRetrying,
+    Retrying,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """Configuration for Tenacity retry execution."""
+
+    attempts: int = 3
+    initial_delay: float = 0.2
+    max_delay: float = 2.0
+    backoff_multiplier: float = 2.0
+    retry_exceptions: tuple[type[BaseException], ...] = (Exception,)
+
+
+def _coerce_exceptions(
+    exceptions: Iterable[type[BaseException]] | tuple[type[BaseException], ...]
+) -> tuple[type[BaseException], ...]:
+    """Ensure ``exceptions`` is a tuple for Tenacity configuration."""
+
+    if isinstance(exceptions, tuple):
+        return exceptions
+    return tuple(exceptions)
+
+
+def call_with_retry(
+    func: Callable[..., T],
+    *args: Any,
+    policy: RetryPolicy | None = None,
+    **kwargs: Any,
+) -> T:
+    """Execute ``func`` with Tenacity retry semantics."""
+
+    resolved_policy = policy or RetryPolicy()
+    retrying = Retrying(
+        retry=retry_if_exception_type(
+            _coerce_exceptions(resolved_policy.retry_exceptions)
+        ),
+        stop=stop_after_attempt(resolved_policy.attempts),
+        wait=wait_exponential(
+            multiplier=resolved_policy.initial_delay,
+            min=resolved_policy.initial_delay,
+            max=resolved_policy.max_delay,
+            exp_base=resolved_policy.backoff_multiplier,
+        ),
+        reraise=True,
+    )
+
+    for attempt in retrying:
+        with attempt:
+            return func(*args, **kwargs)
+
+    # The loop always returns or raises, but mypy requires an explicit return.
+    raise RuntimeError("Retry loop terminated without executing the function.")
+
+
+async def call_async_with_retry(
+    func: Callable[..., Awaitable[T]],
+    *args: Any,
+    policy: RetryPolicy | None = None,
+    **kwargs: Any,
+) -> T:
+    """Execute async ``func`` with Tenacity retry semantics."""
+
+    resolved_policy = policy or RetryPolicy()
+    retrying = AsyncRetrying(
+        retry=retry_if_exception_type(
+            _coerce_exceptions(resolved_policy.retry_exceptions)
+        ),
+        stop=stop_after_attempt(resolved_policy.attempts),
+        wait=wait_exponential(
+            multiplier=resolved_policy.initial_delay,
+            min=resolved_policy.initial_delay,
+            max=resolved_policy.max_delay,
+            exp_base=resolved_policy.backoff_multiplier,
+        ),
+        reraise=True,
+    )
+
+    async for attempt in retrying:
+        with attempt:
+            return await func(*args, **kwargs)
+
+    raise RuntimeError("Async retry loop terminated without executing the function.")
+
+
+__all__ = ["RetryPolicy", "call_with_retry", "call_async_with_retry"]

--- a/services/anonymizer/tests/test_patient_pipeline_resilience.py
+++ b/services/anonymizer/tests/test_patient_pipeline_resilience.py
@@ -1,0 +1,81 @@
+"""Tests covering resilience behaviour in the patient pipeline."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.anonymizer.app.clients.firestore_client import FirestorePatientDocument
+from services.anonymizer.app.pipelines.patient_pipeline import PatientPipeline
+from services.anonymizer.app.pipelines.resilience import RetryPolicy
+
+
+def _build_minimal_patient_document(document_id: str) -> FirestorePatientDocument:
+    return FirestorePatientDocument(document_id=document_id, data={"patient": {}})
+
+
+@pytest.mark.asyncio
+async def test_patient_pipeline_retries_firestore_calls() -> None:
+    firestore = MagicMock()
+    firestore.get_patient_document.side_effect = [
+        RuntimeError("transient firestore error"),
+        _build_minimal_patient_document("doc-123"),
+    ]
+
+    repository = AsyncMock()
+    repository.insert.return_value = [{"document_id": "doc-123"}]
+
+    pipeline = PatientPipeline(
+        firestore_client=firestore,
+        repository=repository,
+        ddl_key="patients",
+        column_mapping={"document_id": "document_id"},
+        retry_policy=RetryPolicy(
+            attempts=2,
+            initial_delay=0.0,
+            max_delay=0.0,
+            backoff_multiplier=1.0,
+        ),
+    )
+
+    summary = await pipeline.run_with_summary("doc-123")
+
+    assert summary.document_id == "doc-123"
+    assert firestore.get_patient_document.call_count == 2
+    repository.insert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_patient_pipeline_gracefully_degrades_on_repository_failure() -> None:
+    firestore = MagicMock()
+    firestore.get_patient_document.return_value = _build_minimal_patient_document(
+        "doc-456"
+    )
+
+    repository = AsyncMock()
+    repository.insert.side_effect = RuntimeError("database unavailable")
+
+    policy = RetryPolicy(
+        attempts=3,
+        initial_delay=0.0,
+        max_delay=0.0,
+        backoff_multiplier=1.0,
+    )
+
+    pipeline = PatientPipeline(
+        firestore_client=firestore,
+        repository=repository,
+        ddl_key="patients",
+        column_mapping={"document_id": "document_id"},
+        retry_policy=policy,
+    )
+
+    summary = await pipeline.run_with_summary("doc-456")
+
+    assert summary.repository_results == ()
+    assert summary.persistence_error is not None
+    assert summary.persistence_succeeded is False
+    assert repository.insert.await_count == policy.attempts
+    # ``run`` should mirror ``run_with_summary`` and surface graceful degradation.
+    assert await pipeline.run("doc-456") == []


### PR DESCRIPTION
## Summary
- add Tenacity-powered retry helpers for anonymizer pipeline modules
- wrap Firestore retrieval and repository persistence with retries and graceful degradation
- add tests covering retry behaviour and degraded persistence responses

## Testing
- pytest services/anonymizer/tests/test_patient_pipeline_resilience.py

------
https://chatgpt.com/codex/tasks/task_e_68dc5f864aa883308e1bbda5ff519411