### PR TITLE
Add anonymizer pipeline and configuration pytest coverage

### DIFF
--- a/services/anonymizer/tests/test_patient_pipeline_anonymization.py
+++ b/services/anonymizer/tests/test_patient_pipeline_anonymization.py
@@ -1,0 +1,119 @@
+"""Unit tests covering anonymisation behaviour within the patient pipeline."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from services.anonymizer.app.anonymization.replacement import ReplacementContext
+from services.anonymizer.app.pipelines.patient_pipeline import (
+    FieldRule,
+    PatientPipeline,
+    PipelineContext,
+)
+
+
+@pytest.fixture()
+def pipeline(monkeypatch: pytest.MonkeyPatch) -> PatientPipeline:
+    """Return a pipeline instance wired with deterministic replacement behaviour."""
+
+    calls: list[tuple[str, str]] = []
+
+    def fake_apply(entity_type: str, text: str, context: ReplacementContext) -> str:
+        calls.append((entity_type, text))
+        # Provide a readable replacement so assertions can inspect it easily.
+        return f"{entity_type}|{text.upper()}"
+
+    monkeypatch.setattr(
+        "services.anonymizer.app.pipelines.patient_pipeline.apply_replacement",
+        fake_apply,
+    )
+
+    field_rules = (
+        FieldRule(("demographics", "first_name"), "PERSON"),
+        FieldRule(("care_team", "*", "name"), "PERSON"),
+        FieldRule(("encounters", "*", "location"), "FACILITY_NAME"),
+    )
+
+    pipeline = PatientPipeline(
+        firestore_client=MagicMock(),
+        repository=MagicMock(),
+        ddl_key="patients",
+        column_mapping={"document_id": "document_id"},
+        field_rules=field_rules,
+        replacement_context_factory=lambda: ReplacementContext(salt="unit-test"),
+    )
+
+    # Attach the captured calls so tests can make assertions.
+    pipeline._replacement_calls = calls  # type: ignore[attr-defined]
+    return pipeline
+
+
+def test_anonymize_patient_payload_applies_field_rules(pipeline: PatientPipeline) -> None:
+    payload = {
+        "demographics": {"first_name": "Jane"},
+        "care_team": [
+            {"name": "Dr. Adams"},
+            {"name": "Dr. Baker", "organization": "Downtown Clinic"},
+        ],
+        "encounters": [
+            {"location": "St. Mary Medical Center"},
+        ],
+    }
+
+    context = PipelineContext(
+        document_id="doc-001",
+        firestore_document={"patient": payload},
+        normalized_document={"patient": payload},
+        patient_payload=payload,
+    )
+
+    anonymized = pipeline._anonymize_patient_payload(payload, context)
+
+    # Ensure replacements were applied to all configured paths.
+    assert anonymized["demographics"]["first_name"].startswith("PERSON|")
+    assert anonymized["care_team"][0]["name"].startswith("PERSON|")
+    assert anonymized["care_team"][1]["name"].startswith("PERSON|")
+    assert anonymized["encounters"][0]["location"].startswith("FACILITY_NAME|")
+
+    # The replacement context should be recorded on the pipeline context for summarisation.
+    assert context.replacement_context is not None
+
+    # Verify ``apply_replacement`` was invoked for each targeted field.
+    assert pipeline._replacement_calls == [
+        ("PERSON", "Jane"),
+        ("PERSON", "Dr. Adams"),
+        ("PERSON", "Dr. Baker"),
+        ("FACILITY_NAME", "St. Mary Medical Center"),
+    ]
+
+
+def test_anonymize_patient_payload_ignores_missing_paths(pipeline: PatientPipeline) -> None:
+    payload = {
+        "demographics": {"first_name": None},
+        "care_team": [],
+        "encounters": [
+            {"location": None},
+            {},
+        ],
+    }
+
+    context = PipelineContext(
+        document_id="doc-002",
+        firestore_document={"patient": payload},
+        normalized_document={"patient": payload},
+        patient_payload=payload,
+    )
+
+    anonymized = pipeline._anonymize_patient_payload(payload, context)
+
+    # ``None`` values should remain untouched to avoid introducing strings where not desired.
+    assert anonymized["demographics"]["first_name"] is None
+    assert anonymized["care_team"] == []
+    assert anonymized["encounters"][0]["location"] is None
+
+    # Only the non-``None`` values should have triggered replacements.
+    assert pipeline._replacement_calls == []

--- a/services/anonymizer/tests/test_pipeline_mapping.py
+++ b/services/anonymizer/tests/test_pipeline_mapping.py
@@ -1,0 +1,78 @@
+"""Tests validating pipeline column mapping utilities."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from services.anonymizer.app.pipelines.patient_pipeline import (
+    PatientPipeline,
+    PipelineContext,
+    build_path_resolver,
+)
+
+
+def test_build_path_resolver_handles_special_roots() -> None:
+    payload = {"demographics": {"first_name": "Ada"}}
+    firestore_document = {"demographics": {"firstName": "Ada"}, "metadata": {"source": "unit"}}
+    normalized_document = {
+        "demographics": {"first_name": "Ada"},
+        "metadata": {"source": "unit"},
+    }
+
+    context = PipelineContext(
+        document_id="doc-123",
+        firestore_document=firestore_document,
+        normalized_document=normalized_document,
+        patient_payload=payload,
+    )
+
+    assert build_path_resolver("document_id")(payload, context) == "doc-123"
+    assert build_path_resolver("raw.metadata.source")(payload, context) == "unit"
+    assert (
+        build_path_resolver("normalized.demographics.first_name")(payload, context)
+        == "Ada"
+    )
+    assert (
+        build_path_resolver("patient.demographics.first_name")(payload, context)
+        == "Ada"
+    )
+    assert build_path_resolver("demographics.first_name")(payload, context) == "Ada"
+
+
+def test_build_row_serialises_complex_values() -> None:
+    payload = {"demographics": {"first_name": "Ada"}}
+    firestore_document = {"metadata": {"source": "unit"}}
+
+    context = PipelineContext(
+        document_id="doc-456",
+        firestore_document=firestore_document,
+        normalized_document={"patient": payload},
+        patient_payload=payload,
+    )
+
+    pipeline = PatientPipeline(
+        firestore_client=MagicMock(),
+        repository=MagicMock(),
+        ddl_key="patients",
+        column_mapping={
+            "document_id": "document_id",
+            "first_name": "patient.demographics.first_name",
+            "metadata": "raw.metadata",
+            "custom": lambda data, ctx: {
+                "doc": ctx.document_id,
+                "names": [data["demographics"]["first_name"]],
+            },
+        },
+    )
+
+    row = pipeline._build_row(payload, context)
+
+    assert row["document_id"] == "doc-456"
+    assert row["first_name"] == "Ada"
+    assert json.loads(row["metadata"]) == {"source": "unit"}
+    assert json.loads(row["custom"]) == {"doc": "doc-456", "names": ["Ada"]}

--- a/services/anonymizer/tests/test_settings_configuration.py
+++ b/services/anonymizer/tests/test_settings_configuration.py
@@ -1,0 +1,52 @@
+"""Tests ensuring environment driven configuration behaves as expected."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from services.anonymizer.app.config.settings import Settings, get_settings
+
+
+def test_settings_resolve_values_from_environment(monkeypatch):
+    monkeypatch.setenv("ANONYMIZER_APP__PORT", "9000")
+    monkeypatch.setenv("ANONYMIZER_PIPELINE__INCLUDE_DEFAULTED", "true")
+    monkeypatch.setenv(
+        "ANONYMIZER_PIPELINE__RETURNING",
+        json.dumps({"patients": ["patient_id", "status"]}),
+    )
+    monkeypatch.setenv("ANONYMIZER_FIRESTORE__PROJECT_ID", "test-project")
+
+    settings = Settings()
+
+    assert settings.app.port == 9000
+    assert settings.pipeline.include_defaulted is True
+    assert settings.pipeline.returning == {"patients": ["patient_id", "status"]}
+    assert settings.firestore.project_id == "test-project"
+
+
+def test_get_settings_returns_cached_instance(monkeypatch):
+    get_settings.cache_clear()
+    monkeypatch.setenv("ANONYMIZER_APP__PORT", "9100")
+
+    first = get_settings()
+    assert first.app.port == 9100
+
+    # Changing the environment after the initial call should not affect the cached instance.
+    monkeypatch.setenv("ANONYMIZER_APP__PORT", "9200")
+    second = get_settings()
+
+    assert second is first
+    assert second.app.port == 9100
+
+    # Clearing the cache allows refreshed configuration to be loaded.
+    get_settings.cache_clear()
+    monkeypatch.delenv("ANONYMIZER_APP__PORT", raising=False)
+    refreshed = get_settings()
+
+    assert refreshed.app.port == 8004
+
+    get_settings.cache_clear()


### PR DESCRIPTION
## Summary
- add unit tests verifying patient pipeline field rules apply deterministic replacements
- add pipeline mapping tests to confirm column resolvers and serialization logic
- add configuration tests to exercise environment-driven settings and caching behaviour

## Testing
- pytest services/anonymizer/tests/test_patient_pipeline_anonymization.py services/anonymizer/tests/test_pipeline_mapping.py services/anonymizer/tests/test_settings_configuration.py *(skipped: missing optional dependency pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68dc62a90810833088750854d59f0820