### PR TITLE
Expand anonymized patient persistence metadata

### DIFF
--- a/docs/anonymizer/development.md
+++ b/docs/anonymizer/development.md
@@ -30,7 +30,7 @@ This guide explains how to set up the anonymizer service for local development, 
 
 ### Seed supporting services
 
-* **PostgreSQL** – Create a database (defaults to `anonymizer`) and apply the DDL shipped with the service. The default mapping writes to `anonymized_patients` as declared in [`services/anonymizer/app/pipelines/ddl/patients.ddl`](../../services/anonymizer/app/pipelines/ddl/patients.ddl).【F:services/anonymizer/app/pipelines/ddl/patients.ddl†L1-L5】
+* **PostgreSQL** – Create a database (defaults to `anonymizer`) and apply the DDL shipped with the service. The default mapping writes to `anonymized_patients` as declared in [`services/anonymizer/app/pipelines/ddl/patients.ddl`](../../services/anonymizer/app/pipelines/ddl/patients.ddl). The table stores the raw Firestore payload, its normalized variant, the extracted patient payload, and the anonymized patient data alongside the originating collection and processing timestamp so downstream analytics can inspect each stage of the pipeline.【F:services/anonymizer/app/pipelines/ddl/patients.ddl†L1-L8】
 * **Firestore** – Populate a `patients` collection with documents that contain a `patient` object shaped like `PatientRecord`. The pipeline normalizes documents and extracts the payload using the shared model definitions.【F:services/anonymizer/app/pipelines/patient_pipeline.py†L343-L367】【F:shared/models/chat.py†L334-L377】
 
 For local testing you can point the service at the Firestore emulator by exporting the standard Google environment variables alongside the anonymizer-specific settings.

--- a/services/anonymizer/app/main.py
+++ b/services/anonymizer/app/main.py
@@ -92,11 +92,37 @@ def _resolve_anonymized_payload(
     return payload
 
 
+def _resolve_collection(_payload: Mapping[str, Any], context: Any) -> str | None:
+    return getattr(context, "collection", None)
+
+
+def _resolve_firestore_document(
+    _payload: Mapping[str, Any], context: Any
+) -> Mapping[str, Any]:
+    return getattr(context, "firestore_document", {})
+
+
+def _resolve_normalized_document(
+    _payload: Mapping[str, Any], context: Any
+) -> Mapping[str, Any]:
+    return getattr(context, "normalized_document", {})
+
+
+def _resolve_patient_payload(
+    _payload: Mapping[str, Any], context: Any
+) -> Mapping[str, Any]:
+    return getattr(context, "patient_payload", {})
+
+
 @lru_cache
 def _build_patient_pipeline() -> PatientPipeline:
     settings = get_settings()
     column_mapping = {
         "document_id": "document_id",
+        "collection": _resolve_collection,
+        "firestore_document": _resolve_firestore_document,
+        "normalized_document": _resolve_normalized_document,
+        "patient_payload": _resolve_patient_payload,
         "anonymized_payload": _resolve_anonymized_payload,
     }
     return PatientPipeline(

--- a/services/anonymizer/app/pipelines/ddl/patients.ddl
+++ b/services/anonymizer/app/pipelines/ddl/patients.ddl
@@ -1,5 +1,9 @@
 CREATE TABLE anonymized_patients (
     document_id TEXT PRIMARY KEY,
+    collection TEXT,
+    firestore_document JSONB NOT NULL,
+    normalized_document JSONB NOT NULL,
+    patient_payload JSONB NOT NULL,
     anonymized_payload JSONB NOT NULL,
     processed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/services/anonymizer/app/pipelines/patient_pipeline.py
+++ b/services/anonymizer/app/pipelines/patient_pipeline.py
@@ -69,6 +69,7 @@ class PipelineContext:
     firestore_document: Mapping[str, Any]
     normalized_document: Mapping[str, Any]
     patient_payload: Mapping[str, Any]
+    collection: str | None = None
     anonymized_patient: Mapping[str, Any] | None = None
     replacement_context: ReplacementContext | None = None
 
@@ -359,6 +360,7 @@ class PatientPipeline:
             firestore_document=document.data,
             normalized_document=deepcopy(normalized_document),
             patient_payload=deepcopy(patient_payload),
+            collection=collection,
         )
 
         anonymized_payload = self._anonymize_patient_payload(patient_payload, context)


### PR DESCRIPTION
## Summary
- expand the anonymized_patients DDL to capture collection, raw Firestore data, normalized payloads, and the anonymized patient JSON
- extend the default patient pipeline context and column mapping so the new table columns are populated automatically
- document the richer persistence layout in the anonymizer development guide

## Testing
- `poetry run python - <<'PY'
from pathlib import Path
from services.anonymizer.app.pipelines import build_mapping_from_files

ddl_path = Path("services/anonymizer/app/pipelines/ddl/patients.ddl")
statements = build_mapping_from_files([ddl_path], include_defaulted=False)
patients_stmt = statements[ddl_path.stem]
print(patients_stmt.table)
print(patients_stmt.columns)
PY`
- `poetry run pytest services/anonymizer/tests` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68dc66ff1ffc833095385fc8a0eabf96