### PR TITLE
Add typed models for Firestore patient documents

### DIFF
--- a/docs/anonymizer/development.md
+++ b/docs/anonymizer/development.md
@@ -31,7 +31,7 @@ This guide explains how to set up the anonymizer service for local development, 
 ### Seed supporting services
 
 * **PostgreSQL** – Create a database (defaults to `anonymizer`) and apply the DDL shipped with the service. The default mapping writes to `anonymized_patients` as declared in [`services/anonymizer/app/pipelines/ddl/patients.ddl`](../../services/anonymizer/app/pipelines/ddl/patients.ddl). The table stores the raw Firestore payload, its normalized variant, the extracted patient payload, and the anonymized patient data alongside the originating collection and processing timestamp so downstream analytics can inspect each stage of the pipeline.【F:services/anonymizer/app/pipelines/ddl/patients.ddl†L1-L8】
-* **Firestore** – Populate a `patients` collection with documents that contain a `patient` object shaped like `PatientRecord`. The pipeline normalizes documents and extracts the payload using the shared model definitions.【F:services/anonymizer/app/pipelines/patient_pipeline.py†L343-L367】【F:shared/models/chat.py†L334-L377】
+* **Firestore** – Populate a `patients` collection with documents that match the structures in `services.anonymizer.app.models.patient`. In particular, the `FirestorePatientDocumentData` model captures the Firestore payload and embeds a `PatientRecord` for the patient-specific content. The pipeline normalizes documents and extracts the payload using these shared definitions.【F:services/anonymizer/app/models/patient.py†L1-L92】【F:services/anonymizer/app/pipelines/patient_pipeline.py†L343-L367】【F:shared/models/chat.py†L334-L377】
 
 For local testing you can point the service at the Firestore emulator by exporting the standard Google environment variables alongside the anonymizer-specific settings.
 

--- a/services/anonymizer/app/models/__init__.py
+++ b/services/anonymizer/app/models/__init__.py
@@ -1,0 +1,15 @@
+"""Typed models exposed by the anonymizer service."""
+
+from .patient import (
+    FirestoreMailingAddress,
+    FirestoreNormalizedPatient,
+    FirestorePatientDocumentData,
+    FirestorePatientDocumentSnapshot,
+)
+
+__all__ = [
+    "FirestoreMailingAddress",
+    "FirestoreNormalizedPatient",
+    "FirestorePatientDocumentData",
+    "FirestorePatientDocumentSnapshot",
+]

--- a/services/anonymizer/app/models/patient.py
+++ b/services/anonymizer/app/models/patient.py
@@ -1,0 +1,88 @@
+"""Pydantic models describing Firestore patient documents."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from shared.models import PatientRecord
+
+__all__ = [
+    "FirestoreMailingAddress",
+    "FirestoreNormalizedPatient",
+    "FirestorePatientDocumentData",
+    "FirestorePatientDocumentSnapshot",
+]
+
+
+class FirestoreMailingAddress(BaseModel):
+    """Structured representation of a patient's mailing address."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    line1: str | None = Field(default=None, alias="line1")
+    line2: str | None = Field(default=None, alias="line2")
+    city: str | None = Field(default=None, alias="city")
+    state: str | None = Field(default=None, alias="state")
+    postal_code: str | None = Field(default=None, alias="postalCode")
+
+
+class FirestoreNormalizedPatient(BaseModel):
+    """Normalized metadata extracted from Firestore documents."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    tenant_id: str | None = Field(default=None, alias="tenantId")
+    facility_id: str | None = Field(default=None, alias="facilityId")
+    ehr_instance_id: str | None = Field(default=None, alias="ehrInstanceId")
+    ehr_external_id: str | None = Field(default=None, alias="ehrExternalId")
+    ehr_connection_status: str | None = Field(
+        default=None, alias="ehrConnectionStatus"
+    )
+    ehr_last_full_manual_sync_at: datetime | str | None = Field(
+        default=None, alias="ehrLastFullManualSyncAt"
+    )
+    legal_mailing_address: FirestoreMailingAddress | None = Field(
+        default=None, alias="legalMailingAddress"
+    )
+    photo_url: str | None = Field(default=None, alias="photoUrl")
+    unit_description: str | None = Field(default=None, alias="unitDescription")
+    floor_description: str | None = Field(default=None, alias="floorDescription")
+    room_description: str | None = Field(default=None, alias="roomDescription")
+    bed_description: str | None = Field(default=None, alias="bedDescription")
+    status: str | None = Field(default=None, alias="status")
+    admission_time: datetime | str | None = Field(default=None, alias="admissionTime")
+    discharge_time: datetime | str | None = Field(default=None, alias="dischargeTime")
+    death_time: datetime | str | None = Field(default=None, alias="deathTime")
+
+
+class FirestorePatientDocumentData(BaseModel):
+    """Payload stored under a Firestore patient document."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    patient: PatientRecord | None = Field(default=None, alias="patient")
+    record: PatientRecord | None = Field(default=None, alias="record")
+    normalized: FirestoreNormalizedPatient | None = Field(
+        default=None, alias="normalized"
+    )
+    metadata: Mapping[str, Any] | None = Field(default=None, alias="metadata")
+    raw: Mapping[str, Any] | None = Field(default=None, alias="raw")
+
+    def patient_payload(self) -> PatientRecord | None:
+        """Return the patient record embedded in the Firestore document."""
+
+        if self.patient is not None:
+            return self.patient
+        return self.record
+
+
+class FirestorePatientDocumentSnapshot(BaseModel):
+    """Typed view over Firestore snapshots returned by the client wrapper."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    document_id: str = Field(alias="documentId")
+    data: FirestorePatientDocumentData


### PR DESCRIPTION
## Summary
- add pydantic models that capture the Firestore patient document payload used by the anonymizer
- expose the new models from the anonymizer models package and update the development guide to reference them

## Testing
- pytest services/anonymizer/tests/test_pipeline_mapping.py

------
https://chatgpt.com/codex/tasks/task_e_68dc8a215fb88330aebf051a96d597c9