### PR TITLE
Align anonymizer patient payload with Firestore schema

### DIFF
--- a/services/anonymizer/app/pipelines/patient_pipeline.py
+++ b/services/anonymizer/app/pipelines/patient_pipeline.py
@@ -528,20 +528,14 @@ def _apply_rule(
 
 
 DEFAULT_FIELD_RULES: tuple[FieldRule, ...] = (
-    FieldRule(("demographics", "first_name"), "PERSON"),
-    FieldRule(("demographics", "middle_name"), "PERSON"),
-    FieldRule(("demographics", "last_name"), "PERSON"),
-    FieldRule(("demographics", "full_name"), "PERSON"),
-    FieldRule(("demographics", "address"), "STREET_ADDRESS"),
-    FieldRule(("demographics", "phone"), "PHONE_NUMBER"),
-    FieldRule(("demographics", "email"), "EMAIL_ADDRESS"),
-    FieldRule(("demographics", "mrn"), "MEDICAL_RECORD_NUMBER"),
-    FieldRule(("care_team", "*", "name"), "PERSON"),
-    FieldRule(("care_team", "*", "organization"), "ORGANIZATION"),
-    FieldRule(("encounters", "*", "provider"), "PERSON"),
-    FieldRule(("encounters", "*", "location"), "FACILITY_NAME"),
-    FieldRule(("clinical_notes", "*", "author"), "PERSON"),
-    FieldRule(("additional_notes", "*", "author"), "PERSON"),
+    FieldRule(("name", "first"), "PERSON"),
+    FieldRule(("name", "last"), "PERSON"),
+    FieldRule(("dob",), "DATE_TIME"),
+    FieldRule(("coverages", "*", "first_name"), "PERSON"),
+    FieldRule(("coverages", "*", "last_name"), "PERSON"),
+    FieldRule(("coverages", "*", "member_id"), "MEDICAL_RECORD_NUMBER"),
+    FieldRule(("coverages", "*", "address", "address_line1"), "STREET_ADDRESS"),
+    FieldRule(("ehr", "patient_id"), "MEDICAL_RECORD_NUMBER"),
 )
 
 

--- a/services/anonymizer/tests/test_patient_pipeline_anonymization.py
+++ b/services/anonymizer/tests/test_patient_pipeline_anonymization.py
@@ -10,9 +10,8 @@ import pytest
 pytest.importorskip("pydantic")
 
 from services.anonymizer.app.anonymization.replacement import ReplacementContext
-from services.anonymizer.app.models import PipelinePatientRecord
 from services.anonymizer.app.pipelines.patient_pipeline import (
-    FieldRule,
+    DEFAULT_FIELD_RULES,
     PatientPipeline,
     PipelineContext,
     PatientPayloadValidationError,
@@ -37,18 +36,12 @@ def pipeline(monkeypatch: pytest.MonkeyPatch) -> PatientPipeline:
         fake_apply,
     )
 
-    field_rules = (
-        FieldRule(("demographics", "first_name"), "PERSON"),
-        FieldRule(("care_team", "*", "name"), "PERSON"),
-        FieldRule(("encounters", "*", "location"), "FACILITY_NAME"),
-    )
-
     pipeline = PatientPipeline(
         firestore_client=MagicMock(),
         repository=MagicMock(),
         ddl_key="patients",
         column_mapping={"document_id": "document_id"},
-        field_rules=field_rules,
+        field_rules=DEFAULT_FIELD_RULES,
         replacement_context_factory=lambda: ReplacementContext(salt="unit-test"),
     )
 
@@ -59,19 +52,88 @@ def pipeline(monkeypatch: pytest.MonkeyPatch) -> PatientPipeline:
 
 @pytest.fixture()
 def patient_payload() -> dict[str, Any]:
-    record = PipelinePatientRecord.model_validate(
-        {
-            "demographics": {"first_name": "Jane"},
-            "care_team": [
-                {"name": "Dr. Adams"},
-                {"name": "Dr. Baker", "organization": "Downtown Clinic"},
-            ],
-            "encounters": [
-                {"location": "St. Mary Medical Center"},
-            ],
-        }
-    )
-    return record.model_dump(mode="json", by_alias=False, exclude_none=True)
+    return {
+        "created_at": 1754272710463,
+        "name": {"prefix": "Ms.", "first": "Nick", "last": "Alderman"},
+        "dob": "1933-05-29",
+        "gender": "female",
+        "coverages": [
+            {
+                "member_id": "8D38CE46-",
+                "payer_name": "INSURANCE_COMPANY_1580",
+                "payer_id": "Unknown",
+                "relationship_to_subscriber": "Self",
+                "first_name": "Nick",
+                "last_name": "Alderman",
+                "gender": "female",
+                "alt_payer_name": "FL MCD MNG-Sunshine State",
+                "insurance_type": "medicaid",
+                "payer_rank": 0,
+                "address": {
+                    "address_line1": "247 Reese Road",
+                    "city": "Tampa",
+                    "state": "FL",
+                    "postal_code": "33605",
+                    "country": "United States",
+                },
+                "plan_effective_date": "2015-04-01",
+            },
+            {
+                "member_id": "Unknown",
+                "payer_name": "Unknown",
+                "payer_id": "Unknown",
+                "relationship_to_subscriber": "Other",
+                "first_name": "Unknown",
+                "last_name": "Unknown",
+                "gender": "unknown",
+                "alt_payer_name": "Resident Liability",
+                "insurance_type": "private",
+                "payer_rank": 1,
+            },
+            {
+                "member_id": "Unknown",
+                "payer_name": "Unknown",
+                "payer_id": "Unknown",
+                "relationship_to_subscriber": "Other",
+                "first_name": "Unknown",
+                "last_name": "Unknown",
+                "gender": "unknown",
+                "alt_payer_name": "Medicare B",
+                "insurance_type": "medicareB",
+                "payer_rank": 2,
+            },
+            {
+                "member_id": "8D38CE46-",
+                "payer_name": "INSURANCE_COMPANY_1580",
+                "payer_id": "Unknown",
+                "relationship_to_subscriber": "Self",
+                "first_name": "Nick",
+                "last_name": "Alderman",
+                "gender": "female",
+                "alt_payer_name": "X-over Medicare B to Medicaid",
+                "insurance_type": "medicaid",
+                "payer_rank": 5,
+                "address": {
+                    "address_line1": "247 Reese Road",
+                    "city": "Tampa",
+                    "state": "FL",
+                    "postal_code": "33605",
+                    "country": "United States",
+                },
+                "plan_effective_date": "2015-04-01",
+            },
+        ],
+        "ehr": {
+            "provider": "PointClickCareSandbox",
+            "instance_id": "92D707EA-E9F9-4B4A-95C3-A98C585A07F7",
+            "patient_id": "6231",
+            "facility_id": "12",
+        },
+        "facility_id": "6ONQmxOcSRWFGkxOHW3V",
+        "facility_name": "Willow Creek Rehabilitation Center",
+        "tenant_id": "Demo-SNF-di0ku",
+        "tenant_name": "Demo SNF",
+    }
 
 
 def test_anonymize_patient_payload_applies_field_rules(
@@ -89,31 +151,56 @@ def test_anonymize_patient_payload_applies_field_rules(
     anonymized = pipeline._anonymize_patient_payload(payload, context)
 
     # Ensure replacements were applied to all configured paths.
-    assert anonymized["demographics"]["first_name"].startswith("PERSON|")
-    assert anonymized["care_team"][0]["name"].startswith("PERSON|")
-    assert anonymized["care_team"][1]["name"].startswith("PERSON|")
-    assert anonymized["encounters"][0]["location"].startswith("FACILITY_NAME|")
+    assert anonymized["name"]["first"].startswith("PERSON|")
+    assert anonymized["name"]["last"].startswith("PERSON|")
+    assert anonymized["dob"].startswith("DATE_TIME|")
+
+    coverage = anonymized["coverages"][0]
+    assert coverage["first_name"].startswith("PERSON|")
+    assert coverage["last_name"].startswith("PERSON|")
+    assert coverage["member_id"].startswith("MEDICAL_RECORD_NUMBER|")
+    assert coverage["address"]["address_line1"].startswith("STREET_ADDRESS|")
+
+    assert anonymized["ehr"]["patient_id"].startswith("MEDICAL_RECORD_NUMBER|")
 
     # The replacement context should be recorded on the pipeline context for summarisation.
     assert context.replacement_context is not None
 
     # Verify ``apply_replacement`` was invoked for each targeted field.
     assert pipeline._replacement_calls == [
-        ("PERSON", "Jane"),
-        ("PERSON", "Dr. Adams"),
-        ("PERSON", "Dr. Baker"),
-        ("FACILITY_NAME", "St. Mary Medical Center"),
+        ("PERSON", "Nick"),
+        ("PERSON", "Alderman"),
+        ("DATE_TIME", "1933-05-29"),
+        ("PERSON", "Nick"),
+        ("PERSON", "Unknown"),
+        ("PERSON", "Unknown"),
+        ("PERSON", "Nick"),
+        ("PERSON", "Alderman"),
+        ("PERSON", "Unknown"),
+        ("PERSON", "Unknown"),
+        ("PERSON", "Alderman"),
+        ("MEDICAL_RECORD_NUMBER", "8D38CE46-"),
+        ("MEDICAL_RECORD_NUMBER", "Unknown"),
+        ("MEDICAL_RECORD_NUMBER", "Unknown"),
+        ("MEDICAL_RECORD_NUMBER", "8D38CE46-"),
+        ("STREET_ADDRESS", "247 Reese Road"),
+        ("STREET_ADDRESS", "247 Reese Road"),
+        ("MEDICAL_RECORD_NUMBER", "6231"),
     ]
 
 
 def test_anonymize_patient_payload_ignores_missing_paths(pipeline: PatientPipeline) -> None:
     payload = {
-        "demographics": {"first_name": None},
-        "care_team": [],
-        "encounters": [
-            {"location": None},
-            {},
+        "name": {"first": None, "last": None},
+        "coverages": [
+            {
+                "member_id": None,
+                "first_name": None,
+                "last_name": None,
+                "address": {"address_line1": None},
+            }
         ],
+        "ehr": {"patient_id": None},
     }
 
     context = PipelineContext(
@@ -126,9 +213,7 @@ def test_anonymize_patient_payload_ignores_missing_paths(pipeline: PatientPipeli
     anonymized = pipeline._anonymize_patient_payload(payload, context)
 
     # ``None`` values should remain untouched to avoid introducing strings where not desired.
-    assert anonymized["demographics"]["first_name"] is None
-    assert anonymized["care_team"] == []
-    assert anonymized["encounters"][0]["location"] is None
+    assert anonymized["name"]["first"] is None
 
     # Only the non-``None`` values should have triggered replacements.
     assert pipeline._replacement_calls == []
@@ -139,10 +224,8 @@ def test_extract_patient_payload_wraps_validation_errors(
 ) -> None:
     invalid_payload = {
         "patient": {
-            "demographics": {
-                "first_name": "Ada",
-                "date_of_birth": "31-02-2020",
-            }
+            "name": {"first": "Ada"},
+            "dob": "31-02-2020",
         }
     }
 
@@ -150,7 +233,7 @@ def test_extract_patient_payload_wraps_validation_errors(
         pipeline._extract_patient_payload(invalid_payload)
 
     message = str(excinfo.value)
-    assert "date_of_birth" in message
+    assert "dob" in message
     assert "31-02-2020" not in message
     assert "Ada" not in message
 
@@ -158,15 +241,31 @@ def test_extract_patient_payload_wraps_validation_errors(
 def test_normalize_structure_strips_unmapped_fields() -> None:
     firestore_payload = {
         "patient": {
-            "demographics": {
-                "firstName": "Ada",
-                "ehrSpecificId": "should-be-removed",
+            "createdAt": 1754272710463,
+            "name": {
+                "first": "Nick",
+                "last": "Alderman",
+                "preferredName": "Nicky",
             },
-            "encounters": [
-                {"location": "Clinic", "ehrEncounterId": "discard"},
-                {"location": "Hospital", "notes": "ok", "extraField": True},
+            "dob": "1933-05-29",
+            "coverages": [
+                {
+                    "memberId": "8D38CE46-",
+                    "firstName": "Nick",
+                    "lastName": "Alderman",
+                    "address": {
+                        "addressLine1": "247 Reese Road",
+                        "geoCode": "remove",
+                    },
+                    "extra": True,
+                }
             ],
-            "unstructuredBlob": {"foo": "bar"},
+            "ehr": {
+                "patientId": "6231",
+                "facilityId": "12",
+                "redundant": "drop",
+            },
+            "legacyField": "should vanish",
         },
         "normalized": {
             "tenantId": "tenant-123",
@@ -183,16 +282,22 @@ def test_normalize_structure_strips_unmapped_fields() -> None:
     normalized = _normalize_structure(firestore_payload)
 
     patient = normalized["patient"]
-    demographics = patient["demographics"]
-    assert demographics == {"first_name": "Ada"}
+    assert patient["created_at"] == 1754272710463
+    assert patient["name"] == {"first": "Nick", "last": "Alderman"}
+    assert patient["dob"] == "1933-05-29"
 
-    encounters = patient["encounters"]
-    assert encounters == [
-        {"location": "Clinic"},
-        {"location": "Hospital", "notes": "ok"},
-    ]
+    coverage = patient["coverages"][0]
+    assert coverage == {
+        "member_id": "8D38CE46-",
+        "first_name": "Nick",
+        "last_name": "Alderman",
+        "address": {"address_line1": "247 Reese Road"},
+    }
 
-    assert "unstructured_blob" not in patient
+    ehr = patient["ehr"]
+    assert ehr == {"patient_id": "6231", "facility_id": "12"}
+
+    assert "legacy_field" not in patient
 
     normalized_meta = normalized["normalized"]
     assert normalized_meta == {
@@ -208,10 +313,13 @@ def test_normalize_structure_strips_unmapped_fields() -> None:
 def test_stringify_structure_masks_unknown_fields() -> None:
     structure = {
         "patient": {
-            "demographics": {
-                "first_name": b"ada",
-                "unwanted": "drop",
-            }
+            "name": {"first": b"ada", "unused": "drop"},
+            "coverages": [
+                {
+                    "first_name": b"nick",
+                    "address": {"address_line1": b"247 Reese Road", "ignore": True},
+                }
+            ],
         },
         "normalized": {
             "tenant_id": "tenant-321",
@@ -222,6 +330,9 @@ def test_stringify_structure_masks_unknown_fields() -> None:
 
     stringified = _stringify_structure(structure)
 
-    assert stringified["patient"]["demographics"] == {"first_name": "ada"}
+    assert stringified["patient"]["name"] == {"first": "ada"}
+    assert stringified["patient"]["coverages"] == [
+        {"first_name": "nick", "address": {"address_line1": "247 Reese Road"}}
+    ]
     assert stringified["normalized"] == {"tenant_id": "tenant-321"}
     assert stringified["raw"] == {"any": "thing"}


### PR DESCRIPTION
## Summary
- model the anonymizer's patient payload with Firestore-specific name, coverage, and EHR structures and drop the dependency on shared chat models
- update the patient pipeline default field rules to target Firestore patient paths such as name, coverages, and EHR identifiers
- refresh the anonymizer pipeline tests to exercise the Firestore-shaped payload, normalization filtering, and replacement coverage

## Testing
- pytest services/anonymizer/tests/test_patient_pipeline_anonymization.py
- pytest services/anonymizer/tests/test_patient_pipeline_resilience.py

------
https://chatgpt.com/codex/tasks/task_e_68dc8f5f4a908330a3579a1ba18ef096