### PR TITLE
Add anonymizer service FastAPI scaffold

### DIFF
--- a/services/anonymizer/__init__.py
+++ b/services/anonymizer/__init__.py
@@ -1,0 +1,5 @@
+"""Anonymizer service package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/services/anonymizer/app.py
+++ b/services/anonymizer/app.py
@@ -1,0 +1,37 @@
+"""FastAPI application providing anonymization capabilities."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, FastAPI
+
+from shared.http.errors import register_exception_handlers
+from shared.observability.logger import configure_logging
+from shared.observability.middleware import (
+    CorrelationIdMiddleware,
+    RequestTimingMiddleware,
+)
+
+SERVICE_NAME = "anonymizer"
+
+configure_logging(service_name=SERVICE_NAME)
+
+app = FastAPI(title="Anonymizer Service")
+router = APIRouter(prefix="/anonymizer", tags=["anonymizer"])
+
+app.add_middleware(RequestTimingMiddleware)
+app.add_middleware(CorrelationIdMiddleware)
+register_exception_handlers(app)
+
+
+@app.get("/health", tags=["health"])
+async def health() -> dict[str, str]:
+    """Return service health status metadata."""
+
+    return {"status": "ok", "service": SERVICE_NAME}
+
+
+# Placeholder routers for anonymization endpoints will be added here in the future.
+app.include_router(router)
+
+
+__all__ = ["app", "health"]


### PR DESCRIPTION
## Summary
- add a FastAPI application skeleton for the anonymizer service with shared logging and middleware
- include a health endpoint and placeholder router for future anonymization APIs
- create a package initializer for the anonymizer service namespace

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc9b2c1fc083309872648e4ec402dd