### PR TITLE
Add entrypoint for anonymizer service

### DIFF
--- a/services/anonymizer/main.py
+++ b/services/anonymizer/main.py
@@ -1,0 +1,21 @@
+"""Entrypoint module for the Anonymizer FastAPI service."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .app import app
+
+__all__ = ["app", "get_app"]
+
+
+def get_app() -> FastAPI:
+    """Return the configured FastAPI application."""
+
+    return app
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import uvicorn
+
+    uvicorn.run("services.anonymizer.main:app")


### PR DESCRIPTION
## Summary
- add an entrypoint module exposing get_app for the anonymizer service
- allow running the anonymizer FastAPI app directly via uvicorn

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc9bd0cb148330b27fef4af67514c4