### PR TITLE
Add Dockerfile for anonymizer service

### DIFF
--- a/services/anonymizer/Dockerfile
+++ b/services/anonymizer/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.5
+
+ARG BASE_IMAGE=ai-chat-ehr-base:latest
+FROM ${BASE_IMAGE} AS runtime
+
+WORKDIR /app
+
+COPY shared ./shared
+COPY services/anonymizer ./services/anonymizer
+
+EXPOSE 8004
+
+CMD ["uvicorn", "services.anonymizer.main:app", "--host", "0.0.0.0", "--port", "8004"]


### PR DESCRIPTION
## Summary
- add a Dockerfile for the anonymizer service based on the shared base image
- copy the shared library and anonymizer package into the container and expose port 8004
- configure the container entrypoint to serve the anonymizer FastAPI app with uvicorn

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc9c8b507c8330b6e739af188ecf0d