### PR TITLE
Add anonymizer service to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,18 @@ services:
       redis:
         condition: service_started
 
+  anonymizer:
+    image: ai-chat-ehr-anonymizer:latest
+    build:
+      context: .
+      dockerfile: services/anonymizer/Dockerfile
+      args:
+        BASE_IMAGE: ${BASE_IMAGE:-ai-chat-ehr-base:latest}
+    env_file:
+      - .env
+    ports:
+      - "8004:8004"
+
   redis:
     image: redis:7-alpine
     ports:


### PR DESCRIPTION
## Summary
- add the anonymizer service to docker-compose so it can be built locally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc9d5a570c8330a04adc24248db8de