### PR TITLE
Add Firestore client abstractions for anonymizer service

### DIFF
--- a/services/anonymizer/firestore/__init__.py
+++ b/services/anonymizer/firestore/__init__.py
@@ -1,0 +1,29 @@
+"""Firestore utilities for the anonymizer service."""
+
+from .client import (
+    ENV_CREDENTIALS,
+    ENV_DATA_SOURCE,
+    ENV_FIXTURE_DIRECTORY,
+    MODE_CREDENTIALS,
+    MODE_FIXTURES,
+    PATIENT_COLLECTION,
+    CredentialedFirestoreDataSource,
+    FirestoreConfigurationError,
+    FirestoreDataSource,
+    FixtureFirestoreDataSource,
+    create_firestore_data_source,
+)
+
+__all__ = [
+    "ENV_CREDENTIALS",
+    "ENV_DATA_SOURCE",
+    "ENV_FIXTURE_DIRECTORY",
+    "MODE_CREDENTIALS",
+    "MODE_FIXTURES",
+    "PATIENT_COLLECTION",
+    "CredentialedFirestoreDataSource",
+    "FirestoreConfigurationError",
+    "FirestoreDataSource",
+    "FixtureFirestoreDataSource",
+    "create_firestore_data_source",
+]

--- a/services/anonymizer/firestore/client.py
+++ b/services/anonymizer/firestore/client.py
@@ -1,0 +1,123 @@
+"""Firestore client abstractions for the anonymizer service."""
+
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from .fixtures import discover_fixture_paths, load_document_fixtures
+
+ENV_DATA_SOURCE = "ANONYMIZER_FIRESTORE_SOURCE"
+ENV_CREDENTIALS = "ANONYMIZER_FIRESTORE_CREDENTIALS"
+ENV_FIXTURE_DIRECTORY = "ANONYMIZER_FIRESTORE_FIXTURES_DIR"
+
+MODE_FIXTURES = "fixtures"
+MODE_CREDENTIALS = "credentials"
+
+PATIENT_COLLECTION = "patients"
+
+
+class FirestoreConfigurationError(RuntimeError):
+    """Raised when Firestore configuration is invalid."""
+
+
+class FirestoreDataSource(ABC):
+    """Interface that encapsulates patient document retrieval from Firestore."""
+
+    @abstractmethod
+    def get_patient(self, collection: str, document_id: str) -> Mapping[str, Any] | None:
+        """Return the patient document from the provided collection."""
+
+
+class FixtureFirestoreDataSource(FirestoreDataSource):
+    """Firestore data source backed by JSON fixtures on disk."""
+
+    def __init__(
+        self,
+        *,
+        collection: str = PATIENT_COLLECTION,
+        fixtures: Mapping[str, Mapping[str, Any]] | None = None,
+        fixture_paths: Iterable[Path] | None = None,
+    ) -> None:
+        if fixtures is None:
+            if fixture_paths is None:
+                fixture_paths = discover_fixture_paths()
+            fixtures = load_document_fixtures(fixture_paths)
+        self._collection = collection
+        self._fixtures = {document_id: dict(payload) for document_id, payload in fixtures.items()}
+
+    def get_patient(self, collection: str, document_id: str) -> Mapping[str, Any] | None:
+        if collection != self._collection:
+            return None
+
+        payload = self._fixtures.get(document_id)
+        if payload is None:
+            return None
+
+        return dict(payload)
+
+
+class CredentialedFirestoreDataSource(FirestoreDataSource):
+    """Placeholder implementation representing a credentialed Firestore client."""
+
+    def __init__(self, *, credentials_path: Path, project_id: str | None = None) -> None:
+        self.credentials_path = Path(credentials_path)
+        self.project_id = project_id
+
+    def get_patient(self, collection: str, document_id: str) -> Mapping[str, Any] | None:  # pragma: no cover - placeholder
+        raise NotImplementedError(
+            "Firestore access requires integration with Google Cloud which is not available in this environment."
+        )
+
+
+def _load_fixture_paths_from_env() -> Iterable[Path] | None:
+    directory = os.getenv(ENV_FIXTURE_DIRECTORY)
+    if not directory:
+        return None
+
+    fixture_dir = Path(directory)
+    if not fixture_dir.exists():
+        raise FirestoreConfigurationError(
+            f"Configured fixture directory '{fixture_dir}' does not exist."
+        )
+
+    return sorted(path for path in fixture_dir.glob("*.json") if path.is_file())
+
+
+def create_firestore_data_source() -> FirestoreDataSource:
+    """Return a configured Firestore data source based on environment variables."""
+
+    mode = os.getenv(ENV_DATA_SOURCE, MODE_FIXTURES).lower()
+
+    if mode == MODE_FIXTURES:
+        fixture_paths = _load_fixture_paths_from_env()
+        return FixtureFirestoreDataSource(fixture_paths=fixture_paths)
+
+    if mode == MODE_CREDENTIALS:
+        credentials_path = os.getenv(ENV_CREDENTIALS)
+        if not credentials_path:
+            raise FirestoreConfigurationError(
+                "Firestore credentials are required when using the credentialed data source."
+            )
+        return CredentialedFirestoreDataSource(credentials_path=Path(credentials_path))
+
+    raise FirestoreConfigurationError(
+        f"Unsupported Firestore data source mode '{mode}'. Supported modes: {MODE_FIXTURES}, {MODE_CREDENTIALS}."
+    )
+
+
+__all__ = [
+    "ENV_CREDENTIALS",
+    "ENV_DATA_SOURCE",
+    "ENV_FIXTURE_DIRECTORY",
+    "MODE_CREDENTIALS",
+    "MODE_FIXTURES",
+    "PATIENT_COLLECTION",
+    "FirestoreDataSource",
+    "FixtureFirestoreDataSource",
+    "CredentialedFirestoreDataSource",
+    "create_firestore_data_source",
+    "FirestoreConfigurationError",
+]

--- a/tests/services/anonymizer/test_firestore_client.py
+++ b/tests/services/anonymizer/test_firestore_client.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import pytest
+
+from services.anonymizer.firestore.client import (
+    CredentialedFirestoreDataSource,
+    FirestoreConfigurationError,
+    FixtureFirestoreDataSource,
+    create_firestore_data_source,
+)
+from services.anonymizer.firestore.client import (
+    ENV_CREDENTIALS,
+    ENV_DATA_SOURCE,
+    ENV_FIXTURE_DIRECTORY,
+    MODE_CREDENTIALS,
+    MODE_FIXTURES,
+)
+
+
+def test_fixture_data_source_returns_patient_from_default_fixtures() -> None:
+    data_source = FixtureFirestoreDataSource()
+
+    patient = data_source.get_patient("patients", "xpF51IBED5TOKMPJamWo")
+
+    assert patient is not None
+    assert patient["name"]["first"] == "Nick"
+
+
+def test_fixture_data_source_returns_none_for_missing_patient() -> None:
+    data_source = FixtureFirestoreDataSource()
+
+    assert data_source.get_patient("patients", "unknown") is None
+
+
+@pytest.mark.parametrize("collection", ["clinicians", "", "Facilities"])
+def test_fixture_data_source_returns_none_for_mismatched_collection(collection: str) -> None:
+    data_source = FixtureFirestoreDataSource()
+
+    assert data_source.get_patient(collection, "xpF51IBED5TOKMPJamWo") is None
+
+
+def test_create_firestore_data_source_defaults_to_fixture_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENV_DATA_SOURCE, raising=False)
+    monkeypatch.delenv(ENV_FIXTURE_DIRECTORY, raising=False)
+
+    data_source = create_firestore_data_source()
+
+    assert isinstance(data_source, FixtureFirestoreDataSource)
+
+
+def test_create_firestore_data_source_uses_custom_fixture_directory(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    fixture = tmp_path / "patients"
+    fixture.mkdir()
+    payload = fixture / "example.json"
+    payload.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setenv(ENV_FIXTURE_DIRECTORY, str(fixture))
+    monkeypatch.delenv(ENV_DATA_SOURCE, raising=False)
+
+    data_source = create_firestore_data_source()
+
+    assert isinstance(data_source, FixtureFirestoreDataSource)
+
+
+def test_create_firestore_data_source_validates_fixture_directory(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_FIXTURE_DIRECTORY, "/does/not/exist")
+
+    with pytest.raises(FirestoreConfigurationError):
+        create_firestore_data_source()
+
+
+def test_create_firestore_data_source_with_credentials_requires_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_DATA_SOURCE, MODE_CREDENTIALS)
+    monkeypatch.delenv(ENV_CREDENTIALS, raising=False)
+
+    with pytest.raises(FirestoreConfigurationError):
+        create_firestore_data_source()
+
+
+def test_create_firestore_data_source_with_credentials_returns_placeholder(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    credentials_path = tmp_path / "credentials.json"
+    credentials_path.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setenv(ENV_DATA_SOURCE, MODE_CREDENTIALS)
+    monkeypatch.setenv(ENV_CREDENTIALS, str(credentials_path))
+
+    data_source = create_firestore_data_source()
+
+    assert isinstance(data_source, CredentialedFirestoreDataSource)
+
+
+def test_create_firestore_data_source_with_unknown_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_DATA_SOURCE, "unknown")
+
+    with pytest.raises(FirestoreConfigurationError):
+        create_firestore_data_source()


### PR DESCRIPTION
## Summary
- add a FirestoreDataSource interface with a fixture-backed implementation for patient lookups
- provide a credential-aware placeholder path for future Firestore integrations and expose module exports
- cover the new data source behaviour with targeted tests

## Testing
- pytest tests/services/anonymizer/test_firestore_client.py

------
https://chatgpt.com/codex/tasks/task_e_68dca1c263948330acbf5b8aa910c2ea