### PR TITLE
Add Pydantic models for Firestore and Postgres patient data

### DIFF
--- a/services/anonymizer/models/__init__.py
+++ b/services/anonymizer/models/__init__.py
@@ -1,0 +1,19 @@
+"""Pydantic data models used by the anonymizer service."""
+
+from .firestore import (  # noqa: F401
+    FirestoreAddress,
+    FirestoreCoverage,
+    FirestoreEHRMetadata,
+    FirestoreName,
+    FirestorePatientDocument,
+)
+from .postgres import PatientRow  # noqa: F401
+
+__all__ = [
+    "FirestoreAddress",
+    "FirestoreCoverage",
+    "FirestoreEHRMetadata",
+    "FirestoreName",
+    "FirestorePatientDocument",
+    "PatientRow",
+]

--- a/services/anonymizer/models/firestore.py
+++ b/services/anonymizer/models/firestore.py
@@ -1,0 +1,99 @@
+"""Pydantic models representing Firestore patient documents."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+def _to_camel(value: str) -> str:
+    """Return ``value`` converted from snake_case to camelCase."""
+
+    components = value.split("_")
+    if not components:
+        return value
+    first, *rest = components
+    return first + "".join(token.capitalize() for token in rest)
+
+
+class FirestoreModel(BaseModel):
+    """Base model for Firestore payloads using camelCase aliases."""
+
+    model_config = ConfigDict(
+        alias_generator=_to_camel,
+        populate_by_name=True,
+        extra="ignore",
+    )
+
+
+class FirestoreName(FirestoreModel):
+    """Patient name metadata stored in Firestore."""
+
+    prefix: Optional[str] = Field(default=None, description="Optional name prefix")
+    first: str = Field(description="Patient given name")
+    middle: Optional[str] = Field(default=None, description="Patient middle name")
+    last: str = Field(description="Patient family name")
+    suffix: Optional[str] = Field(default=None, description="Optional name suffix")
+
+
+class FirestoreAddress(FirestoreModel):
+    """Postal address nested under a coverage entry."""
+
+    address_line1: Optional[str] = Field(default=None)
+    address_line2: Optional[str] = Field(default=None)
+    city: Optional[str] = Field(default=None)
+    state: Optional[str] = Field(default=None)
+    postal_code: Optional[str] = Field(default=None)
+    country: Optional[str] = Field(default=None)
+
+
+class FirestoreCoverage(FirestoreModel):
+    """Insurance coverage information stored alongside the patient."""
+
+    member_id: Optional[str] = Field(default=None)
+    payer_name: Optional[str] = Field(default=None)
+    payer_id: Optional[str] = Field(default=None)
+    relationship_to_subscriber: Optional[str] = Field(default=None)
+    first_name: Optional[str] = Field(default=None)
+    last_name: Optional[str] = Field(default=None)
+    gender: Optional[str] = Field(default=None)
+    alt_payer_name: Optional[str] = Field(default=None)
+    insurance_type: Optional[str] = Field(default=None)
+    payer_rank: Optional[int] = Field(default=None)
+    address: Optional[FirestoreAddress] = Field(default=None)
+    plan_effective_date: Optional[date] = Field(default=None)
+
+
+class FirestoreEHRMetadata(FirestoreModel):
+    """Metadata describing the originating EHR system."""
+
+    provider: Optional[str] = Field(default=None)
+    instance_id: Optional[str] = Field(default=None)
+    patient_id: Optional[str] = Field(default=None)
+    facility_id: Optional[str] = Field(default=None)
+
+
+class FirestorePatientDocument(FirestoreModel):
+    """Top-level structure of the Firestore patient document."""
+
+    created_at: Optional[int] = Field(default=None)
+    name: FirestoreName = Field(description="Patient name components")
+    dob: Optional[date] = Field(default=None, description="Patient date of birth")
+    gender: Optional[str] = Field(default=None)
+    coverages: list[FirestoreCoverage] = Field(default_factory=list)
+    ehr: Optional[FirestoreEHRMetadata] = Field(default=None)
+    facility_id: Optional[str] = Field(default=None)
+    facility_name: Optional[str] = Field(default=None)
+    tenant_id: Optional[str] = Field(default=None)
+    tenant_name: Optional[str] = Field(default=None)
+
+
+__all__ = [
+    "FirestoreAddress",
+    "FirestoreCoverage",
+    "FirestoreEHRMetadata",
+    "FirestoreName",
+    "FirestorePatientDocument",
+]

--- a/services/anonymizer/models/postgres.py
+++ b/services/anonymizer/models/postgres.py
@@ -1,0 +1,43 @@
+"""Data model for rows written to ``public.patient`` in Postgres."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any, Optional
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PatientRow(BaseModel):
+    """Representation of a ``public.patient`` row destined for Postgres."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    id: UUID = Field(default_factory=uuid4)
+    tenant_id: UUID = Field(description="Identifier of the owning tenant")
+    facility_id: UUID = Field(description="Identifier of the owning facility")
+    ehr_instance_id: Optional[UUID] = Field(default=None)
+    ehr_external_id: Optional[str] = Field(default=None)
+    ehr_connection_status: Optional[str] = Field(default=None)
+    ehr_last_full_manual_sync_at: Optional[datetime] = Field(default=None)
+    name_first: str = Field(description="Patient given name")
+    name_last: str = Field(description="Patient family name")
+    dob: Optional[date] = Field(default=None)
+    gender: str = Field(description="Patient gender enum value")
+    ethnicity_description: Optional[str] = Field(default=None)
+    legal_mailing_address: Optional[dict[str, Any]] = Field(default=None)
+    photo_url: Optional[str] = Field(default=None)
+    unit_description: Optional[str] = Field(default=None)
+    floor_description: Optional[str] = Field(default=None)
+    room_description: Optional[str] = Field(default=None)
+    bed_description: Optional[str] = Field(default=None)
+    status: str = Field(description="Patient status enum value")
+    admission_time: Optional[datetime] = Field(default=None)
+    discharge_time: Optional[datetime] = Field(default=None)
+    death_time: Optional[datetime] = Field(default=None)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+__all__ = ["PatientRow"]


### PR DESCRIPTION
## Summary
- add Firestore patient document models covering nested name, coverage, and EHR metadata structures
- add a Postgres `public.patient` row model capturing field types and defaults for inserts

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dca29c79f4833093fdeba0debb39c8