### PR TITLE
Add anonymizer reporting summary helper

### DIFF
--- a/services/anonymizer/reporting.py
+++ b/services/anonymizer/reporting.py
@@ -1,0 +1,81 @@
+"""Reporting helpers for the anonymizer service."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from typing import Any, Iterable, Mapping
+
+
+def summarize_transformations(
+    transformations: Iterable[Mapping[str, Any]]
+) -> dict[str, Any]:
+    """Aggregate anonymization transformations into a JSON friendly summary.
+
+    The anonymizer may record individual transformation events that include
+    sensitive values such as the original piece of PHI.  This helper collapses
+    those events into high level counts grouped by entity type and action
+    ensuring that the returned payload is JSON serializable and does not
+    include any raw PHI strings.
+
+    Parameters
+    ----------
+    transformations:
+        Iterable of mapping-like records describing the transformations that
+        were applied.  Each record is expected to expose an ``entity_type`` (or
+        ``entity``) field describing the identified Presidio entity and an
+        ``action`` (or ``strategy``) field describing how the entity was
+        anonymized.
+
+    Returns
+    -------
+    dict[str, Any]
+        Summary dictionary with keys:
+
+        ``total_transformations``
+            Total number of transformations encountered.
+
+        ``actions``
+            Mapping of action name to the number of occurrences.
+
+        ``entities``
+            Nested mapping keyed by entity type containing the per-entity
+            transformation counts and the distribution of anonymization
+            actions.
+    """
+
+    total = 0
+    action_counts: Counter[str] = Counter()
+    entity_stats: defaultdict[str, dict[str, Any]] = defaultdict(
+        lambda: {"count": 0, "actions": Counter()}
+    )
+
+    for record in transformations:
+        if not isinstance(record, Mapping):
+            continue
+
+        entity = record.get("entity_type") or record.get("entity") or "UNKNOWN"
+        action = record.get("action") or record.get("strategy") or "unknown"
+
+        entity = str(entity)
+        action = str(action)
+
+        total += 1
+        action_counts[action] += 1
+        entity_stats[entity]["count"] += 1
+        entity_stats[entity]["actions"][action] += 1
+
+    return {
+        "total_transformations": total,
+        "actions": dict(sorted(action_counts.items())),
+        "entities": {
+            entity: {
+                "count": stats["count"],
+                "actions": dict(sorted(stats["actions"].items())),
+            }
+            for entity, stats in sorted(entity_stats.items())
+        },
+    }
+
+
+__all__ = ["summarize_transformations"]
+

--- a/tests/services/anonymizer/test_reporting.py
+++ b/tests/services/anonymizer/test_reporting.py
@@ -1,0 +1,84 @@
+"""Tests for anonymizer reporting helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+REPORTING_PATH = ROOT / "services" / "anonymizer" / "reporting.py"
+_SPEC = importlib.util.spec_from_file_location(
+    "services.anonymizer.reporting", REPORTING_PATH
+)
+if _SPEC is None or _SPEC.loader is None:  # pragma: no cover - defensive guard
+    raise RuntimeError("Unable to load reporting module for tests")
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+summarize_transformations = getattr(_MODULE, "summarize_transformations")
+
+
+def test_summarize_transformations_basic() -> None:
+    events = [
+        {"entity_type": "PERSON", "action": "redact", "original": "John Doe"},
+        {"entity_type": "PERSON", "action": "redact", "original": "Jane Doe"},
+        {"entity_type": "PHONE_NUMBER", "action": "replace", "original": "555-5555"},
+    ]
+
+    summary = summarize_transformations(events)
+
+    assert summary == {
+        "total_transformations": 3,
+        "actions": {"redact": 2, "replace": 1},
+        "entities": {
+            "PERSON": {"count": 2, "actions": {"redact": 2}},
+            "PHONE_NUMBER": {"count": 1, "actions": {"replace": 1}},
+        },
+    }
+
+    serialized = json.dumps(summary)
+    assert "John Doe" not in serialized
+    assert "Jane Doe" not in serialized
+    assert "555-5555" not in serialized
+
+
+@pytest.mark.parametrize(
+    "events, expected",
+    [
+        (
+            [
+                {"entity": "EMAIL_ADDRESS", "strategy": "synthesize"},
+                {"entity_type": "UNKNOWN_TYPE", "action": None},
+                "not-a-mapping",
+            ],
+            {
+                "total_transformations": 2,
+                "actions": {"synthesize": 1, "unknown": 1},
+                "entities": {
+                    "EMAIL_ADDRESS": {"count": 1, "actions": {"synthesize": 1}},
+                    "UNKNOWN_TYPE": {"count": 1, "actions": {"unknown": 1}},
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "total_transformations": 0,
+                "actions": {},
+                "entities": {},
+            },
+        ),
+    ],
+)
+def test_summarize_transformations_varied(events, expected) -> None:
+    summary = summarize_transformations(events)
+    assert summary == expected
+    # Ensure the result can be serialized into JSON without errors.
+    json.dumps(summary)
+


### PR DESCRIPTION
## Summary
- add a reporting helper that aggregates transformation events without exposing raw PHI
- convert the counts into a JSON-serializable structure grouped by action and entity
- cover the helper with focused unit tests

## Testing
- pytest tests/services/anonymizer/test_reporting.py

------
https://chatgpt.com/codex/tasks/task_e_68dca66774208330a81e3192d484074a