### PR TITLE
Add anonymization response schemas and transformation summary support

### DIFF
--- a/services/anonymizer/schemas.py
+++ b/services/anonymizer/schemas.py
@@ -1,0 +1,69 @@
+"""Pydantic response models exposed by the anonymizer API."""
+
+from __future__ import annotations
+
+from typing import Dict, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class EntityActionSummary(BaseModel):
+    """Summary of anonymization actions applied to a particular entity type."""
+
+    count: int = Field(..., ge=0, description="Number of transformations for the entity type.")
+    actions: Dict[str, int] = Field(
+        default_factory=dict,
+        description="Mapping of anonymization actions to their occurrence counts.",
+    )
+
+
+class TransformationAggregates(BaseModel):
+    """Aggregated anonymization statistics across the processed document."""
+
+    total_transformations: int = Field(
+        ...,
+        ge=0,
+        description="Total number of transformation events collected during anonymization.",
+    )
+    actions: Dict[str, int] = Field(
+        default_factory=dict,
+        description="Mapping of anonymization actions to their overall occurrence counts.",
+    )
+    entities: Dict[str, EntityActionSummary] = Field(
+        default_factory=dict,
+        description="Per-entity breakdown of anonymization actions and counts.",
+    )
+
+
+class TransformationSummary(BaseModel):
+    """Response payload summarizing anonymization activity for a patient document."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    record_id: UUID = Field(
+        ..., alias="recordId", description="Identifier of the persisted anonymized patient record."
+    )
+    transformations: TransformationAggregates = Field(
+        ..., description="Aggregated statistics describing the transformation events."
+    )
+
+
+class AnonymizeResponse(BaseModel):
+    """Standard response returned from the anonymization endpoint."""
+
+    status: Literal["accepted"] = Field(
+        ..., description="Status indicator that the anonymization request has been accepted."
+    )
+    summary: TransformationSummary = Field(
+        ..., description="Summary of the anonymization results for the processed document."
+    )
+
+
+__all__ = [
+    "EntityActionSummary",
+    "TransformationAggregates",
+    "TransformationSummary",
+    "AnonymizeResponse",
+]
+

--- a/services/anonymizer/service.py
+++ b/services/anonymizer/service.py
@@ -111,8 +111,12 @@ async def process_patient(
     firestore: FirestoreDataSource | None = None,
     anonymizer: PresidioAnonymizerEngine | None = None,
     storage: PostgresStorage | None = None,
-) -> UUID:
-    """Fetch, anonymize, and persist a patient record from Firestore."""
+) -> tuple[UUID, list[TransformationEvent]]:
+    """Fetch, anonymize, and persist a patient record from Firestore.
+
+    Returns a tuple containing the persisted patient UUID along with the
+    collected transformation events emitted by the anonymizer engine.
+    """
 
     deps = _resolve_dependencies(firestore=firestore, anonymizer=anonymizer, storage=storage)
 
@@ -163,7 +167,7 @@ async def process_patient(
             patient_row=scrub_for_logging(patient_row),
             transformation_event_count=len(transformation_events),
         )
-        return patient_id
+        return patient_id, transformation_events
     except ConstraintViolationError as exc:
         raise DuplicatePatientError(
             "An anonymized patient record already exists for this facility and EHR source.",


### PR DESCRIPTION
## Summary
- update the patient processing workflow to return collected transformation events
- add typed FastAPI response models for the anonymization endpoint payloads
- include the transformation summary in the anonymize document response and logging

## Testing
- pytest tests/services/anonymizer -q *(fails: missing presidio_analyzer / pydantic runtime dependencies in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcb1c2e20c8330995e18991c136879