### PR TITLE
Load anonymizer settings from root env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,3 +87,20 @@ DATABASE_URL=
 # ---------------------------------------------------------------------------
 # Redis connection string used by background workers and caches.
 REDIS_URL=redis://redis:6379/0
+
+# ---------------------------------------------------------------------------
+# Anonymizer service configuration
+# ---------------------------------------------------------------------------
+# Data source used to fetch patient documents. Use "fixtures" to read the local
+# JSON files included with the repository or "credentials" to connect to a real
+# Firestore project using service account credentials.
+ANONYMIZER_FIRESTORE_SOURCE=fixtures
+# Directory containing patient fixture JSON files when
+# ANONYMIZER_FIRESTORE_SOURCE=fixtures.
+ANONYMIZER_FIRESTORE_FIXTURES_DIR=services/anonymizer/firestore_fixtures/patients
+# Absolute path to the Google service account JSON file used when
+# ANONYMIZER_FIRESTORE_SOURCE=credentials.
+ANONYMIZER_FIRESTORE_CREDENTIALS=/secrets/service-account.json
+# SQLAlchemy-compatible Postgres DSN used by the anonymizer storage layer for
+# persisting anonymized patient rows.
+ANONYMIZER_POSTGRES_DSN=postgresql+psycopg://user:pass@db:5432/anonymizer

--- a/services/anonymizer/__init__.py
+++ b/services/anonymizer/__init__.py
@@ -1,5 +1,11 @@
 """Anonymizer service package."""
 
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[2] / ".env", override=False)
+
 from .presidio_engine import (
     AnonymizationAction,
     EntityAnonymizationRule,


### PR DESCRIPTION
## Summary
- load the root .env file when the anonymizer package is imported so service-specific environment variables are available
- document the anonymizer environment variables in .env.example with guidance on their usage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcb5b15e0c833081eb0aa5abb4e64e