### PR TITLE
Add anonymizer fixture runner script

### DIFF
--- a/scripts/run_anonymizer.py
+++ b/scripts/run_anonymizer.py
@@ -1,0 +1,109 @@
+"""Utility script for anonymizing fixture-backed Firestore documents."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from typing import Iterable
+
+from services.anonymizer.firestore.client import (
+    FixtureFirestoreDataSource,
+    PATIENT_COLLECTION,
+)
+from services.anonymizer.firestore.fixtures import discover_fixture_paths
+from services.anonymizer.presidio_engine import PresidioAnonymizerEngine
+from services.anonymizer.reporting import summarize_transformations
+from services.anonymizer.service import process_patient
+from services.anonymizer.storage.postgres import PostgresStorage
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fetch a patient document from Firestore fixtures, anonymize it, and "
+            "persist the result to Postgres."
+        )
+    )
+    parser.add_argument(
+        "collection",
+        nargs="?",
+        default=PATIENT_COLLECTION,
+        help=f"Firestore collection containing the patient document (default: {PATIENT_COLLECTION}).",
+    )
+    parser.add_argument(
+        "document_id",
+        help="Firestore document identifier to anonymize.",
+    )
+    parser.add_argument(
+        "--postgres-dsn",
+        dest="postgres_dsn",
+        required=True,
+        help="Postgres DSN used for inserting the anonymized patient row.",
+    )
+    parser.add_argument(
+        "--dump-summary",
+        action="store_true",
+        help="Emit a JSON summary of the transformations that were applied.",
+    )
+    parser.add_argument(
+        "--bootstrap-schema",
+        dest="bootstrap_schema",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Control whether the anonymizer patient schema should be bootstrapped before inserting rows.",
+    )
+    return parser
+
+
+async def _run_async(args: argparse.Namespace) -> int:
+    fixture_paths = discover_fixture_paths()
+    firestore = FixtureFirestoreDataSource(
+        collection=args.collection,
+        fixture_paths=fixture_paths,
+    )
+    storage = PostgresStorage(
+        args.postgres_dsn,
+        bootstrap_schema=args.bootstrap_schema,
+    )
+    anonymizer = PresidioAnonymizerEngine()
+
+    try:
+        patient_id, transformation_events = await process_patient(
+            args.collection,
+            args.document_id,
+            firestore=firestore,
+            anonymizer=anonymizer,
+            storage=storage,
+        )
+    finally:
+        storage.close()
+
+    print(f"Persisted anonymized patient {patient_id}")
+
+    if args.dump_summary:
+        summary = summarize_transformations(
+            event.model_dump() if hasattr(event, "model_dump") else event
+            for event in transformation_events
+        )
+        print("Transformation summary:")
+        print(json.dumps(summary, indent=2))
+
+    return 0
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return asyncio.run(_run_async(args))
+    except KeyboardInterrupt:  # pragma: no cover - manual cancellation guard
+        return 130
+    except Exception as exc:  # pragma: no cover - surface script errors cleanly
+        print(str(exc), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/services/anonymizer/README.md
+++ b/services/anonymizer/README.md
@@ -19,6 +19,18 @@ The default development workflow loads documents from JSON fixtures under `servi
 
 When `ANONYMIZER_FIRESTORE_SOURCE=credentials`, the service instantiates a placeholder Firestore client that expects `ANONYMIZER_FIRESTORE_CREDENTIALS` to point to a service account JSON file. This path is validated before the service starts so misconfigurations fail fast.
 
+### Fixture smoke test
+
+The repository bundles a helper script for exercising the anonymizer against the fixture-backed Firestore data source without starting the FastAPI service. Provide the document identifier and a Postgres DSN (for example, a local dev instance) to fetch the fixture, anonymize it, and persist the resulting patient row:
+
+```bash
+python scripts/run_anonymizer.py xpF51IBED5TOKMPJamWo \
+  --postgres-dsn postgresql://postgres:postgres@localhost:5432/postgres \
+  --dump-summary
+```
+
+Add `--no-bootstrap-schema` when the target database already contains the anonymizer tables.
+
 ## Dry-run SQL output
 
 Set `ANONYMIZER_STORAGE_MODE=sqlfile` to review anonymized patient rows without writing

--- a/tests/scripts/test_run_anonymizer.py
+++ b/tests/scripts/test_run_anonymizer.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+from typing import Iterable
+from uuid import UUID, uuid4
+
+import pytest
+
+from scripts import run_anonymizer
+from services.anonymizer.models import TransformationEvent
+
+
+class _StubStorage:
+    instances: list["_StubStorage"] = []
+
+    def __init__(self, dsn: str, *, bootstrap_schema: bool) -> None:  # type: ignore[override]
+        self.dsn = dsn
+        self.bootstrap_schema = bootstrap_schema
+        self.closed = False
+        type(self).instances.append(self)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _reset_storage_instances() -> Iterable[None]:
+    _StubStorage.instances.clear()
+    yield
+    _StubStorage.instances.clear()
+
+
+def _install_stubs(monkeypatch: pytest.MonkeyPatch, *, patient_id: UUID, events: list[TransformationEvent]) -> None:
+    async def _fake_process_patient(
+        collection: str,
+        document_id: str,
+        *,
+        firestore,
+        anonymizer,
+        storage,
+    ):
+        # ensure the fixture data source can locate the bundled patient record
+        fixture_payload = firestore.get_patient(collection, document_id)
+        assert fixture_payload is not None
+        assert storage.dsn == "postgresql://anonymizer"
+        return patient_id, events
+
+    monkeypatch.setattr(run_anonymizer, "PostgresStorage", _StubStorage)
+    monkeypatch.setattr(run_anonymizer, "process_patient", _fake_process_patient)
+
+
+def test_main_processes_fixture_and_prints_summary(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    patient_id = uuid4()
+    events = [
+        TransformationEvent(entity_type="NAME", action="replace", start=0, end=4, surrogate="HASHED"),
+        TransformationEvent(entity_type="PHONE", action="redact", start=10, end=21, surrogate="***"),
+    ]
+
+    _install_stubs(monkeypatch, patient_id=patient_id, events=events)
+
+    exit_code = run_anonymizer.main(
+        [
+            "patients",
+            "xpF51IBED5TOKMPJamWo",
+            "--postgres-dsn",
+            "postgresql://anonymizer",
+            "--dump-summary",
+            "--no-bootstrap-schema",
+        ]
+    )
+
+    assert exit_code == 0
+
+    captured = capsys.readouterr().out.splitlines()
+    assert any(str(patient_id) in line for line in captured)
+    assert any("Transformation summary:" in line for line in captured)
+
+    summary_json = "\n".join(line for line in captured if line and line.strip().startswith("{"))
+    summary = json.loads(summary_json)
+    assert summary["total_transformations"] == len(events)
+    assert "NAME" in summary["entities"]
+    assert "PHONE" in summary["entities"]
+
+    assert _StubStorage.instances and _StubStorage.instances[0].bootstrap_schema is False
+    assert _StubStorage.instances[0].closed is True
+
+
+def test_main_bootstraps_schema_by_default(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    patient_id = uuid4()
+    events: list[TransformationEvent] = []
+
+    _install_stubs(monkeypatch, patient_id=patient_id, events=events)
+
+    exit_code = run_anonymizer.main(
+        [
+            "xpF51IBED5TOKMPJamWo",
+            "--postgres-dsn",
+            "postgresql://anonymizer",
+        ]
+    )
+
+    assert exit_code == 0
+
+    assert _StubStorage.instances and _StubStorage.instances[0].bootstrap_schema is True
+    assert _StubStorage.instances[0].closed is True
+
+    captured = capsys.readouterr()
+    assert str(patient_id) in captured.out


### PR DESCRIPTION
## Summary
- add a CLI helper that anonymizes fixture-backed Firestore patients into Postgres
- support optional schema bootstrap toggles and transformation summaries
- add smoke tests and README guidance covering the script workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcc3525c488330b333a78438189c40