### PR TITLE
Add anonymizer service VS Code launch and task entries

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -68,6 +68,23 @@
             "console": "integratedTerminal",
             "envFile": "${workspaceFolder}/.env",
             "preLaunchTask": "Install dependencies"
+        },
+        {
+            "name": "Anonymizer",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "uvicorn",
+            "args": [
+                "services.anonymizer.main:app",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8004"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "envFile": "${workspaceFolder}/.env",
+            "preLaunchTask": "Install dependencies"
         }
     ],
     "compounds": [
@@ -77,7 +94,8 @@
                 "API Gateway",
                 "Prompt Catalog",
                 "Patient Context",
-                "Chain Executor"
+                "Chain Executor",
+                "Anonymizer"
             ],
             "stopAll": true
         }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -132,6 +132,33 @@
             "problemMatcher": [],
             "dependsOn": "Install dependencies",
             "dependsOrder": "sequence"
+        },
+        {
+            "label": "Run Anonymizer",
+            "type": "process",
+            "command": "${command:python.interpreterPath}",
+            "args": [
+                "-m",
+                "uvicorn",
+                "services.anonymizer.main:app",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8004",
+                "--reload"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated",
+                "group": "Microservices",
+                "close": true
+            },
+            "problemMatcher": [],
+            "dependsOn": "Install dependencies",
+            "dependsOrder": "sequence"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- add a VS Code launch configuration for the anonymizer microservice
- add a VS Code task to run the anonymizer service and include it in the compound configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcc58a8b0c833095180fa3b4135e90