### PR TITLE
Add structured patient processing error reporting

### DIFF
--- a/services/anonymizer/app.py
+++ b/services/anonymizer/app.py
@@ -169,6 +169,10 @@ async def handle_patient_processing(
             "due to an upstream error."
         )
 
+    processing_details = getattr(exc, "details", None)
+    if processing_details:
+        extras["processingError"] = dict(processing_details)
+
     status_code = status.HTTP_502_BAD_GATEWAY
     return _problem_response(
         request=request,


### PR DESCRIPTION
## Summary
- attach structured phase metadata to `PatientProcessingError` and raise it from `process_patient`
- include processing error details in the anonymizer API problem responses
- extend anonymizer route tests to cover structured error payloads and process failure scenarios

## Testing
- pytest tests/services/anonymizer/test_app_anonymize_document.py

------
https://chatgpt.com/codex/tasks/task_e_68dcc4d31660833097363f73945816b2