### PR TITLE
Document credentialed Firestore environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,10 @@ ANONYMIZER_FIRESTORE_FIXTURES_DIR=services/anonymizer/firestore_fixtures/patient
 # Absolute path to the Google service account JSON file used when
 # ANONYMIZER_FIRESTORE_SOURCE=credentials.
 ANONYMIZER_FIRESTORE_CREDENTIALS=/secrets/service-account.json
+# Optional Google Cloud project ID override when connecting with
+# ANONYMIZER_FIRESTORE_SOURCE=credentials. When omitted, the project from the
+# service account file is used.
+ANONYMIZER_FIRESTORE_PROJECT=
 # SQLAlchemy-compatible Postgres DSN used by the anonymizer storage layer for
 # persisting anonymized patient rows when ANONYMIZER_STORAGE_MODE=database.
 ANONYMIZER_POSTGRES_DSN=postgresql+psycopg://user:pass@db:5432/anonymizer

--- a/README.md
+++ b/README.md
@@ -109,7 +109,15 @@ Provide the database DSN via `ANONYMIZER_POSTGRES_DSN` (or switch to
 `ANONYMIZER_STORAGE_MODE=sqlfile` to emit `INSERT` statements for review) in your
 `.env` file or shell environment before launching the service. When running with
 Docker Compose the service reads the same `.env` file, so add any Firestore
-emulator credentials or service account configuration there as well.
+emulator credentials or service account configuration there as well. When
+connecting to a real Firestore instance, set the following variables:
+
+* `ANONYMIZER_FIRESTORE_SOURCE=credentials` to enable the credentialed data
+  source.
+* `ANONYMIZER_FIRESTORE_CREDENTIALS` with the absolute path to the service
+  account JSON file that has Firestore access.
+* `ANONYMIZER_FIRESTORE_PROJECT` (optional) when you need to override the
+  project embedded in the service account file.
 
 Start the FastAPI application locally (see the commands above) or rely on Docker
 Compose to publish it on <http://localhost:8004>. Once online, trigger

--- a/tests/services/anonymizer/test_firestore_client.py
+++ b/tests/services/anonymizer/test_firestore_client.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 import sys
+import types
+from typing import Any, Mapping
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
@@ -10,9 +12,47 @@ if str(PROJECT_ROOT) not in sys.path:
 
 import pytest
 
+if "dotenv" not in sys.modules:
+    dotenv_stub = types.ModuleType("dotenv")
+    dotenv_stub.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = dotenv_stub
+
+if "services.anonymizer" not in sys.modules:
+    anonymizer_stub = types.ModuleType("services.anonymizer")
+    anonymizer_stub.__path__ = [str(PROJECT_ROOT / "services" / "anonymizer")]
+    sys.modules["services.anonymizer"] = anonymizer_stub
+
+if "presidio_analyzer" not in sys.modules:
+    presidio_stub = types.ModuleType("presidio_analyzer")
+
+    class _AnalyzerEngine:
+        def __init__(self) -> None:
+            self.registry = types.SimpleNamespace(add_recognizer=lambda *args, **kwargs: None)
+
+    class _Pattern:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - simple stub
+            self.args = args
+            self.kwargs = kwargs
+
+    class _PatternRecognizer:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - simple stub
+            self.args = args
+            self.kwargs = kwargs
+
+    class _RecognizerResult:
+        pass
+
+    presidio_stub.AnalyzerEngine = _AnalyzerEngine
+    presidio_stub.Pattern = _Pattern
+    presidio_stub.PatternRecognizer = _PatternRecognizer
+    presidio_stub.RecognizerResult = _RecognizerResult
+
+    sys.modules["presidio_analyzer"] = presidio_stub
+
 from services.anonymizer.firestore.client import (
     CredentialedFirestoreDataSource,
     FirestoreConfigurationError,
+    FirestoreDataSourceError,
     FixtureFirestoreDataSource,
     create_firestore_data_source,
 )
@@ -20,9 +60,56 @@ from services.anonymizer.firestore.client import (
     ENV_CREDENTIALS,
     ENV_DATA_SOURCE,
     ENV_FIXTURE_DIRECTORY,
+    ENV_PROJECT_ID,
     MODE_CREDENTIALS,
     MODE_FIXTURES,
 )
+
+
+class _StubDocumentSnapshot:
+    def __init__(self, *, exists: bool, payload: Mapping[str, Any] | None) -> None:
+        self.exists = exists
+        self._payload = payload
+
+    def to_dict(self) -> Mapping[str, Any] | None:
+        return self._payload
+
+
+class _StubDocumentReference:
+    def __init__(self, *, snapshot: _StubDocumentSnapshot | None, error: Exception | None = None) -> None:
+        self._snapshot = snapshot
+        self._error = error
+
+    def get(self) -> _StubDocumentSnapshot:
+        if self._error:
+            raise self._error
+        assert self._snapshot is not None
+        return self._snapshot
+
+
+class _StubCollectionReference:
+    def __init__(self) -> None:
+        self.requests: list[str] = []
+        self._document: _StubDocumentReference | None = None
+
+    def set_document(self, document: _StubDocumentReference) -> None:
+        self._document = document
+
+    def document(self, document_id: str) -> _StubDocumentReference:
+        self.requests.append(document_id)
+        assert self._document is not None
+        return self._document
+
+
+class _StubFirestoreClient:
+    def __init__(self, *, snapshot: _StubDocumentSnapshot | None = None, error: Exception | None = None) -> None:
+        self.collection_calls: list[str] = []
+        self._collection = _StubCollectionReference()
+        self._collection.set_document(_StubDocumentReference(snapshot=snapshot, error=error))
+
+    def collection(self, name: str) -> _StubCollectionReference:
+        self.collection_calls.append(name)
+        return self._collection
 
 
 def test_fixture_data_source_returns_patient_from_default_fixtures() -> None:
@@ -85,16 +172,26 @@ def test_create_firestore_data_source_with_credentials_requires_path(monkeypatch
         create_firestore_data_source()
 
 
-def test_create_firestore_data_source_with_credentials_returns_placeholder(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_create_firestore_data_source_with_credentials_returns_client(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     credentials_path = tmp_path / "credentials.json"
     credentials_path.write_text("{}", encoding="utf-8")
 
+    monkeypatch.setattr(
+        CredentialedFirestoreDataSource,
+        "_create_client",
+        lambda self: object(),
+    )
+
     monkeypatch.setenv(ENV_DATA_SOURCE, MODE_CREDENTIALS)
     monkeypatch.setenv(ENV_CREDENTIALS, str(credentials_path))
+    monkeypatch.setenv(ENV_PROJECT_ID, "example-project")
 
     data_source = create_firestore_data_source()
 
     assert isinstance(data_source, CredentialedFirestoreDataSource)
+    assert data_source.project_id == "example-project"
 
 
 def test_create_firestore_data_source_with_unknown_mode(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -102,3 +199,65 @@ def test_create_firestore_data_source_with_unknown_mode(monkeypatch: pytest.Monk
 
     with pytest.raises(FirestoreConfigurationError):
         create_firestore_data_source()
+
+
+def test_credentialed_firestore_data_source_returns_document(tmp_path: Path) -> None:
+    credentials_path = tmp_path / "credentials.json"
+    credentials_path.write_text("{}", encoding="utf-8")
+
+    snapshot = _StubDocumentSnapshot(exists=True, payload={"name": "Ada"})
+    client = _StubFirestoreClient(snapshot=snapshot)
+
+    data_source = CredentialedFirestoreDataSource(
+        credentials_path=credentials_path,
+        project_id="proj-123",
+        client=client,
+    )
+
+    patient = data_source.get_patient("patients", "secret-id")
+
+    assert patient == {"name": "Ada"}
+    assert client.collection_calls == ["patients"]
+
+
+def test_credentialed_firestore_data_source_returns_none_for_missing_document(tmp_path: Path) -> None:
+    credentials_path = tmp_path / "credentials.json"
+    credentials_path.write_text("{}", encoding="utf-8")
+
+    snapshot = _StubDocumentSnapshot(exists=False, payload=None)
+    client = _StubFirestoreClient(snapshot=snapshot)
+
+    data_source = CredentialedFirestoreDataSource(
+        credentials_path=credentials_path,
+        client=client,
+    )
+
+    assert data_source.get_patient("patients", "secret-id") is None
+
+
+def test_credentialed_firestore_data_source_wraps_errors(tmp_path: Path) -> None:
+    credentials_path = tmp_path / "credentials.json"
+    credentials_path.write_text("{}", encoding="utf-8")
+
+    error = RuntimeError("dangerous secret-id exposed")
+    client = _StubFirestoreClient(snapshot=None, error=error)
+
+    data_source = CredentialedFirestoreDataSource(
+        credentials_path=credentials_path,
+        project_id="proj-123",
+        client=client,
+    )
+
+    with pytest.raises(FirestoreDataSourceError) as exc_info:
+        data_source.get_patient("patients", "secret-id")
+
+    message = str(exc_info.value)
+    assert "secret-id" not in message
+    assert "<redacted>" in message
+    assert "patients" in message
+    assert exc_info.value.context == {
+        "collection": "patients",
+        "document_id": "<redacted>",
+        "project_id": "proj-123",
+        "error_type": "RuntimeError",
+    }


### PR DESCRIPTION
## Summary
- document the anonymizer Firestore project override in `.env.example`
- outline the required environment variables in the README for credentialed Firestore access

## Testing
- pytest tests/services/anonymizer/test_firestore_client.py

------
https://chatgpt.com/codex/tasks/task_e_68dcc729cdd483308b87e457d1bdbec5