### PR TITLE
Clarify Docker Compose readiness behavior in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ defaults if unset.
    docker compose up --build
    ```
    The compose file ensures Redis comes online before the downstream APIs, and
-   the API gateway only starts once its dependencies report healthy. The
+   the API gateway waits for its dependencies to start (readiness still requires
+   health checks if you need that guarantee). The
    containers expose the service ports listed above on `localhost`. Use
    `docker compose down` to stop the stack when you finish testing.
 


### PR DESCRIPTION
## Summary
- clarify that the Docker Compose dependencies only control startup order without health checks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcc96903888330af621c27f7dd1ab0