### PR TITLE
Normalize case-insensitive chain category handling

### DIFF
--- a/services/chain_executor/app.py
+++ b/services/chain_executor/app.py
@@ -361,9 +361,10 @@ class _CategoryCacheEntry:
 # concurrently by the event loop.
 _CATEGORY_CACHE_LOCK = asyncio.Lock()
 _CATEGORY_CLASSIFICATION_CACHE: "OrderedDict[str, _CategoryCacheEntry]" = OrderedDict()
-_KNOWN_CATEGORY_SLUGS: frozenset[str] = frozenset(
-    category.slug for category in DEFAULT_PROMPT_CATEGORIES
-)
+_CATEGORY_SLUG_MAP: dict[str, str] = {
+    category.slug.casefold(): category.slug for category in DEFAULT_PROMPT_CATEGORIES
+}
+_KNOWN_CATEGORY_SLUGS: frozenset[str] = frozenset(_CATEGORY_SLUG_MAP.values())
 
 
 def _filter_valid_categories(values: Iterable[str]) -> list[str]:
@@ -373,12 +374,13 @@ def _filter_valid_categories(values: Iterable[str]) -> list[str]:
         slug = value.strip()
         if not slug:
             continue
-        if slug not in _KNOWN_CATEGORY_SLUGS:
+        canonical = _CATEGORY_SLUG_MAP.get(slug.casefold())
+        if canonical is None:
             continue
-        if slug in seen:
+        if canonical in seen:
             continue
-        seen.add(slug)
-        ordered.append(slug)
+        seen.add(canonical)
+        ordered.append(canonical)
     return ordered
 
 

--- a/tests/chain_executor/test_execute_chain.py
+++ b/tests/chain_executor/test_execute_chain.py
@@ -445,7 +445,7 @@ async def test_execute_chain_prefers_prompt_categories_for_patient_context(
         key=ChatPromptKey.PATIENT_SUMMARY,
         template="Summary: {symptom}",
         input_variables=["symptom"],
-        metadata={"categories": ["labs", "invalid", "notes"]},
+        metadata={"categories": [" Labs ", "invalid", "NOTES"]},
     )
 
     payload = {
@@ -453,7 +453,7 @@ async def test_execute_chain_prefers_prompt_categories_for_patient_context(
         "variables": {"symptom": "fatigue"},
         "modelProvider": "openai/gpt-3.5-turbo",
         "patientId": "patient-123",
-        "categories": ["vitals", "medications"],
+        "categories": ["ViTaLs", "medications"],
     }
 
     result = await _execute_chain_request(
@@ -512,7 +512,7 @@ async def test_execute_chain_uses_request_categories_when_prompt_missing(
         "variables": {"symptom": "fatigue"},
         "modelProvider": "openai/gpt-3.5-turbo",
         "patientId": "patient-456",
-        "categories": ["vitals", "unknown", "medications"],
+        "categories": [" VITALS ", "unknown", "MEDICATIONS"],
     }
 
     result = await _execute_chain_request(


### PR DESCRIPTION
## Summary
- update chain executor category filtering to map case-insensitively to canonical slugs
- keep prompt metadata using canonical category slugs
- adjust chain executor tests to cover mixed-case category inputs

## Testing
- pytest tests/chain_executor/test_execute_chain.py *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68dcc974b674833089da1be1c6545fcd