### PR TITLE
Fix ruff formatting and lint violations

### DIFF
--- a/services/anonymizer/__init__.py
+++ b/services/anonymizer/__init__.py
@@ -4,8 +4,6 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-load_dotenv(Path(__file__).resolve().parents[2] / ".env", override=False)
-
 from .presidio_engine import (
     AnonymizationAction,
     EntityAnonymizationRule,
@@ -24,3 +22,5 @@ __all__ = [
 ]
 
 __version__ = "0.1.0"
+
+load_dotenv(Path(__file__).resolve().parents[2] / ".env", override=False)

--- a/services/anonymizer/app.py
+++ b/services/anonymizer/app.py
@@ -58,7 +58,9 @@ def _document_surrogate_id(path_params: Mapping[str, Any]) -> str | None:
     if not token:
         return None
 
-    surrogate_uuid = uuid5(NAMESPACE_URL, f"https://chatehr.ai/anonymizer/document/{token}")
+    surrogate_uuid = uuid5(
+        NAMESPACE_URL, f"https://chatehr.ai/anonymizer/document/{token}"
+    )
     return f"doc-{surrogate_uuid}"
 
 
@@ -232,7 +234,9 @@ async def anonymize_document(
             detail="Collection and document identifiers must be non-empty strings.",
         )
 
-    patient_id, transformation_events = await process_patient(collection_token, document_token)
+    patient_id, transformation_events = await process_patient(
+        collection_token, document_token
+    )
 
     transformation_summary = summarize_transformations(transformation_events)
     aggregates = TransformationAggregates.model_validate(transformation_summary)
@@ -260,6 +264,7 @@ async def anonymize_document(
     )
 
     return response_payload
+
 
 # Placeholder routers for anonymization endpoints will be added here in the future.
 app.include_router(router)

--- a/services/anonymizer/firestore/client.py
+++ b/services/anonymizer/firestore/client.py
@@ -27,7 +27,9 @@ class FirestoreConfigurationError(RuntimeError):
 class FirestoreDataSourceError(RuntimeError):
     """Raised when Firestore access fails in a sanitized manner."""
 
-    def __init__(self, message: str, *, context: Mapping[str, Any] | None = None) -> None:
+    def __init__(
+        self, message: str, *, context: Mapping[str, Any] | None = None
+    ) -> None:
         super().__init__(message)
         self.context = dict(context or {})
 
@@ -36,7 +38,9 @@ class FirestoreDataSource(ABC):
     """Interface that encapsulates patient document retrieval from Firestore."""
 
     @abstractmethod
-    def get_patient(self, collection: str, document_id: str) -> Mapping[str, Any] | None:
+    def get_patient(
+        self, collection: str, document_id: str
+    ) -> Mapping[str, Any] | None:
         """Return the patient document from the provided collection."""
 
 
@@ -55,9 +59,13 @@ class FixtureFirestoreDataSource(FirestoreDataSource):
                 fixture_paths = discover_fixture_paths()
             fixtures = load_document_fixtures(fixture_paths)
         self._collection = collection
-        self._fixtures = {document_id: dict(payload) for document_id, payload in fixtures.items()}
+        self._fixtures = {
+            document_id: dict(payload) for document_id, payload in fixtures.items()
+        }
 
-    def get_patient(self, collection: str, document_id: str) -> Mapping[str, Any] | None:
+    def get_patient(
+        self, collection: str, document_id: str
+    ) -> Mapping[str, Any] | None:
         if collection != self._collection:
             return None
 
@@ -99,9 +107,13 @@ class CredentialedFirestoreDataSource(FirestoreDataSource):
         if self.project_id:
             kwargs["project"] = self.project_id
 
-        return firestore.Client.from_service_account_json(str(self.credentials_path), **kwargs)
+        return firestore.Client.from_service_account_json(
+            str(self.credentials_path), **kwargs
+        )
 
-    def _raise_sanitized_error(self, collection: str, document_id: str, error: Exception) -> None:
+    def _raise_sanitized_error(
+        self, collection: str, document_id: str, error: Exception
+    ) -> None:
         error_type = error.__class__.__name__
         message = (
             "Failed to fetch Firestore document '<redacted>' "
@@ -115,11 +127,17 @@ class CredentialedFirestoreDataSource(FirestoreDataSource):
         }
         raise FirestoreDataSourceError(message, context=context) from None
 
-    def get_patient(self, collection: str, document_id: str) -> Mapping[str, Any] | None:
+    def get_patient(
+        self, collection: str, document_id: str
+    ) -> Mapping[str, Any] | None:
         try:
-            document_reference = self._client.collection(collection).document(document_id)
+            document_reference = self._client.collection(collection).document(
+                document_id
+            )
             snapshot = document_reference.get()
-        except Exception as exc:  # pragma: no cover - error paths validated via unit tests
+        except (
+            Exception
+        ) as exc:  # pragma: no cover - error paths validated via unit tests
             self._raise_sanitized_error(collection, document_id, exc)
         if not getattr(snapshot, "exists", False):
             return None

--- a/services/anonymizer/firestore/fixtures.py
+++ b/services/anonymizer/firestore/fixtures.py
@@ -72,9 +72,7 @@ def discover_fixture_paths() -> list[Path]:
     if not _FIXTURE_DIRECTORY.exists():
         return []
 
-    return sorted(
-        path for path in _FIXTURE_DIRECTORY.glob("*.json") if path.is_file()
-    )
+    return sorted(path for path in _FIXTURE_DIRECTORY.glob("*.json") if path.is_file())
 
 
 __all__ = ["FixtureLoadError", "load_document_fixtures", "discover_fixture_paths"]

--- a/services/anonymizer/logging_utils.py
+++ b/services/anonymizer/logging_utils.py
@@ -16,12 +16,16 @@ except Exception:  # pragma: no cover - pydantic is expected but make defensive
     BaseModel = None  # type: ignore[assignment]
 
 if TYPE_CHECKING:  # pragma: no cover - for static analysis only
-    from services.anonymizer.models.firestore import FirestorePatientDocument as _FirestorePatientDocument
+    from services.anonymizer.models.firestore import (
+        FirestorePatientDocument as _FirestorePatientDocument,
+    )
 else:
     _FirestorePatientDocument = Any
 
 try:  # pragma: no cover - optional dependency guard
-    from services.anonymizer.models.firestore import FirestorePatientDocument as _RuntimeFirestorePatientDocument
+    from services.anonymizer.models.firestore import (
+        FirestorePatientDocument as _RuntimeFirestorePatientDocument,
+    )
 except Exception:  # pragma: no cover - allow usage without Firestore models installed
     _RuntimeFirestorePatientDocument = None
 
@@ -67,7 +71,9 @@ def scrub_for_logging(
         allowed.update(key.lower() for key in allow_keys)
 
     seen: set[int] = set()
-    transformation_event_keys = frozenset({"entity_type", "action", "start", "end", "surrogate"})
+    transformation_event_keys = frozenset(
+        {"entity_type", "action", "start", "end", "surrogate"}
+    )
 
     def _coerce_transformation_event(obj: Any) -> Mapping[str, Any] | None:
         """Return a mapping when ``obj`` looks like a TransformationEvent."""
@@ -79,13 +85,17 @@ def scrub_for_logging(
         if hasattr(obj, "model_dump"):
             try:
                 payload = obj.model_dump(mode="python")  # type: ignore[call-arg]
-            except Exception:  # pragma: no cover - defensive guard against custom models
+            except (
+                Exception
+            ):  # pragma: no cover - defensive guard against custom models
                 payload = None
             if isinstance(payload, Mapping) and _has_required_keys(payload):
                 return payload
 
         if is_dataclass(obj):
-            field_names = {name.lower() for name in getattr(obj, "__dataclass_fields__", {})}
+            field_names = {
+                name.lower() for name in getattr(obj, "__dataclass_fields__", {})
+            }
             if transformation_event_keys.issubset(field_names):
                 marker = id(obj)
                 if marker in seen:
@@ -103,7 +113,9 @@ def scrub_for_logging(
 
         return None
 
-    def _scrub_transformation_event(payload: Mapping[str, Any], depth: int) -> Mapping[str, Any]:
+    def _scrub_transformation_event(
+        payload: Mapping[str, Any], depth: int
+    ) -> Mapping[str, Any]:
         sanitized: dict[str, Any] = {"__type__": "TransformationEvent"}
 
         entity = payload.get("entity_type") or payload.get("entity") or "UNKNOWN"
@@ -133,7 +145,15 @@ def scrub_for_logging(
         for key, value in payload.items():
             key_str = str(key)
             lowered = key_str.lower()
-            if lowered in {"entity_type", "entity", "action", "strategy", "start", "end", "surrogate"}:
+            if lowered in {
+                "entity_type",
+                "entity",
+                "action",
+                "strategy",
+                "start",
+                "end",
+                "surrogate",
+            }:
                 continue
             sanitized[key_str] = _scrub(value, depth - 1)
 
@@ -194,7 +214,9 @@ def scrub_for_logging(
                 return sanitized
             finally:
                 seen.remove(marker)
-        if isinstance(obj, Collection) and not isinstance(obj, (str, bytes, bytearray, Mapping)):
+        if isinstance(obj, Collection) and not isinstance(
+            obj, (str, bytes, bytearray, Mapping)
+        ):
             marker = id(obj)
             if marker in seen:
                 return redaction
@@ -202,7 +224,10 @@ def scrub_for_logging(
             try:
                 count = len(obj)
                 sample = [_scrub(item, depth - 1) for item in islice(obj, max_items)]
-                summary: dict[str, Any] = {"count": count, "__type__": type(obj).__name__}
+                summary: dict[str, Any] = {
+                    "count": count,
+                    "__type__": type(obj).__name__,
+                }
                 if sample:
                     summary["sample"] = sample
                 if count > len(sample):
@@ -216,7 +241,7 @@ def scrub_for_logging(
 
 
 def summarize_patient_document(
-    document: "_FirestorePatientDocument" | Mapping[str, Any]
+    document: "_FirestorePatientDocument" | Mapping[str, Any],
 ) -> dict[str, Any]:
     """Return high-level metadata about a Firestore patient document."""
 
@@ -231,13 +256,23 @@ def summarize_patient_document(
     elif isinstance(document, Mapping):
         data = document
     else:  # pragma: no cover - defensive guard for unexpected types
-        raise TypeError("document must be a mapping or FirestorePatientDocument-like object")
+        raise TypeError(
+            "document must be a mapping or FirestorePatientDocument-like object"
+        )
 
     name = data.get("name") or {}
     if not isinstance(name, Mapping):
         name = {}
     name_components = sum(
-        1 for part in (name.get("prefix"), name.get("first"), name.get("middle"), name.get("last"), name.get("suffix")) if part
+        1
+        for part in (
+            name.get("prefix"),
+            name.get("first"),
+            name.get("middle"),
+            name.get("last"),
+            name.get("suffix"),
+        )
+        if part
     )
 
     coverages = data.get("coverages") or []
@@ -248,7 +283,9 @@ def summarize_patient_document(
         for item in coverages:
             if isinstance(item, Mapping):
                 yield item
-            elif _RuntimeFirestorePatientDocument is not None and hasattr(item, "model_dump"):
+            elif _RuntimeFirestorePatientDocument is not None and hasattr(
+                item, "model_dump"
+            ):
                 yield item.model_dump(mode="python")  # type: ignore[call-arg]
 
     coverage_items = list(_coverage_iter())
@@ -273,11 +310,19 @@ def summarize_patient_document(
         "has_dob": bool(data.get("dob")),
         "has_gender": bool(data.get("gender")),
         "coverage_count": len(coverage_items),
-        "coverages_with_member_id": sum(1 for coverage in coverage_items if coverage.get("member_id")),
-        "coverages_with_address": sum(1 for coverage in coverage_items if coverage.get("address")),
+        "coverages_with_member_id": sum(
+            1 for coverage in coverage_items if coverage.get("member_id")
+        ),
+        "coverages_with_address": sum(
+            1 for coverage in coverage_items if coverage.get("address")
+        ),
         "ehr_metadata_present": bool(data.get("ehr")),
-        "facility_metadata_present": bool(data.get("facility_id") or data.get("facility_name")),
-        "tenant_metadata_present": bool(data.get("tenant_id") or data.get("tenant_name")),
+        "facility_metadata_present": bool(
+            data.get("facility_id") or data.get("facility_name")
+        ),
+        "tenant_metadata_present": bool(
+            data.get("tenant_id") or data.get("tenant_name")
+        ),
         "transformation_event_count": transformation_event_count,
         "transformation_summary_present": bool(data.get("transformation_summary")),
     }

--- a/services/anonymizer/models/transformation_event.py
+++ b/services/anonymizer/models/transformation_event.py
@@ -8,10 +8,18 @@ from pydantic import BaseModel, Field
 class TransformationEvent(BaseModel):
     """Summary of a single anonymization transformation."""
 
-    entity_type: str = Field(..., description="Presidio entity type that was transformed.")
+    entity_type: str = Field(
+        ..., description="Presidio entity type that was transformed."
+    )
     action: str = Field(..., description="Anonymization operator that was applied.")
-    start: int = Field(..., ge=0, description="Inclusive starting character index of the transformation.")
-    end: int = Field(..., ge=0, description="Exclusive ending character index of the transformation.")
+    start: int = Field(
+        ...,
+        ge=0,
+        description="Inclusive starting character index of the transformation.",
+    )
+    end: int = Field(
+        ..., ge=0, description="Exclusive ending character index of the transformation."
+    )
     surrogate: str = Field(
         ...,
         description=(

--- a/services/anonymizer/presidio_engine.py
+++ b/services/anonymizer/presidio_engine.py
@@ -9,7 +9,12 @@ import hmac
 import re
 from typing import Callable, Iterable, Mapping, MutableSequence
 
-from presidio_analyzer import AnalyzerEngine, Pattern, PatternRecognizer, RecognizerResult
+from presidio_analyzer import (
+    AnalyzerEngine,
+    Pattern,
+    PatternRecognizer,
+    RecognizerResult,
+)
 
 from .models import TransformationEvent
 
@@ -69,9 +74,7 @@ class PresidioEngineConfig:
     """User configurable settings for :class:`PresidioAnonymizerEngine`."""
 
     default_action: AnonymizationAction = AnonymizationAction.REPLACE
-    entity_policies: Mapping[str, EntityAnonymizationRule] = field(
-        default_factory=dict
-    )
+    entity_policies: Mapping[str, EntityAnonymizationRule] = field(default_factory=dict)
     hash_secret: str = "ai-chat-ehr-safe-harbor"
     hash_prefix: str = "anon"
     hash_length: int = 12
@@ -234,7 +237,10 @@ class PresidioAnonymizerEngine:
         self._config = config or PresidioEngineConfig()
         self._analyzer = analyzer or _build_default_analyzer()
         self._synthesizer = synthesizer
-        if self._config.default_action is AnonymizationAction.SYNTHESIZE and not synthesizer:
+        if (
+            self._config.default_action is AnonymizationAction.SYNTHESIZE
+            and not synthesizer
+        ):
             self._synthesizer = OpenAILLMSynthesizer(model=self._config.llm_model)
 
     def anonymize(
@@ -283,8 +289,12 @@ class PresidioAnonymizerEngine:
                 )
 
         anonymized_text = text
-        for start, end, replacement in sorted(replacements, key=lambda r: r[0], reverse=True):
-            anonymized_text = anonymized_text[:start] + replacement + anonymized_text[end:]
+        for start, end, replacement in sorted(
+            replacements, key=lambda r: r[0], reverse=True
+        ):
+            anonymized_text = (
+                anonymized_text[:start] + replacement + anonymized_text[end:]
+            )
 
         anonymized_text = self._generalize_ages(anonymized_text)
         if collect_events:
@@ -333,12 +343,14 @@ class PresidioAnonymizerEngine:
         window = self._config.context_window
         start_context = max(result.start - window, 0)
         end_context = min(result.end + window, len(text))
-        context = text[start_context:result.start] + text[result.end:end_context]
+        context = text[start_context : result.start] + text[result.end : end_context]
 
         return self._synthesizer(result.entity_type, original_value, context or None)
 
     @staticmethod
-    def _overlaps(result: RecognizerResult, occupied: Iterable[tuple[int, int]]) -> bool:
+    def _overlaps(
+        result: RecognizerResult, occupied: Iterable[tuple[int, int]]
+    ) -> bool:
         for start, end in occupied:
             if result.start < end and start < result.end:
                 return True
@@ -374,4 +386,3 @@ __all__ = [
     "PresidioEngineConfig",
     "SAFE_HARBOR_ENTITIES",
 ]
-

--- a/services/anonymizer/reporting.py
+++ b/services/anonymizer/reporting.py
@@ -120,4 +120,3 @@ def summarize_transformations(
 
 
 __all__ = ["summarize_transformations"]
-

--- a/services/anonymizer/schemas.py
+++ b/services/anonymizer/schemas.py
@@ -11,7 +11,9 @@ from pydantic import BaseModel, ConfigDict, Field
 class EntityActionSummary(BaseModel):
     """Summary of anonymization actions applied to a particular entity type."""
 
-    count: int = Field(..., ge=0, description="Number of transformations for the entity type.")
+    count: int = Field(
+        ..., ge=0, description="Number of transformations for the entity type."
+    )
     actions: Dict[str, int] = Field(
         default_factory=dict,
         description="Mapping of anonymization actions to their occurrence counts.",
@@ -42,7 +44,9 @@ class TransformationSummary(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     record_id: UUID = Field(
-        ..., alias="recordId", description="Identifier of the persisted anonymized patient record."
+        ...,
+        alias="recordId",
+        description="Identifier of the persisted anonymized patient record.",
     )
     transformations: TransformationAggregates = Field(
         ..., description="Aggregated statistics describing the transformation events."
@@ -53,10 +57,12 @@ class AnonymizeResponse(BaseModel):
     """Standard response returned from the anonymization endpoint."""
 
     status: Literal["accepted"] = Field(
-        ..., description="Status indicator that the anonymization request has been accepted."
+        ...,
+        description="Status indicator that the anonymization request has been accepted.",
     )
     summary: TransformationSummary = Field(
-        ..., description="Summary of the anonymization results for the processed document."
+        ...,
+        description="Summary of the anonymization results for the processed document.",
     )
 
 
@@ -66,4 +72,3 @@ __all__ = [
     "TransformationSummary",
     "AnonymizeResponse",
 ]
-

--- a/services/anonymizer/service.py
+++ b/services/anonymizer/service.py
@@ -180,7 +180,9 @@ class PatientProcessingError(RuntimeError):
             sanitized["phase"] = phase
         if details:
             sanitized.update(details)
-        self.phase: ProcessingPhase | None = cast(ProcessingPhase | None, sanitized.get("phase"))
+        self.phase: ProcessingPhase | None = cast(
+            ProcessingPhase | None, sanitized.get("phase")
+        )
         self._details = MappingProxyType(dict(sanitized))
 
     @property
@@ -361,7 +363,9 @@ async def process_patient(
     collected transformation events emitted by the anonymizer engine.
     """
 
-    deps = _resolve_dependencies(firestore=firestore, anonymizer=anonymizer, storage=storage)
+    deps = _resolve_dependencies(
+        firestore=firestore, anonymizer=anonymizer, storage=storage
+    )
 
     try:
         payload = deps.firestore.get_patient(collection, document_id)
@@ -425,7 +429,9 @@ async def process_patient(
             transformation_event_count=len(transformation_events),
             total_transformations=transformation_summary["total_transformations"],
             transformation_actions=scrub_for_logging(transformation_summary["actions"]),
-            transformation_entities=scrub_for_logging(transformation_summary["entities"]),
+            transformation_entities=scrub_for_logging(
+                transformation_summary["entities"]
+            ),
             transformation_summary=scrub_for_logging(transformation_summary),
         )
         return patient_id, transformation_events
@@ -448,11 +454,17 @@ def _resolve_dependencies(
 ) -> _ServiceDependencies:
     if firestore or anonymizer or storage:
         if firestore is None:
-            raise ServiceConfigurationError("A Firestore data source must be provided when overriding dependencies.")
+            raise ServiceConfigurationError(
+                "A Firestore data source must be provided when overriding dependencies."
+            )
         if storage is None:
-            raise ServiceConfigurationError("A patient storage instance must be provided when overriding dependencies.")
+            raise ServiceConfigurationError(
+                "A patient storage instance must be provided when overriding dependencies."
+            )
         anonymizer = anonymizer or PresidioAnonymizerEngine()
-        return _ServiceDependencies(firestore=firestore, anonymizer=anonymizer, storage=storage)
+        return _ServiceDependencies(
+            firestore=firestore, anonymizer=anonymizer, storage=storage
+        )
 
     return _get_dependencies()
 
@@ -469,11 +481,21 @@ def _anonymize_document(
     original_ehr_instance_id = document.ehr.instance_id if document.ehr else None
     original_ehr_patient_id = document.ehr.patient_id if document.ehr else None
 
-    anonymized.name.first = _anonymize_text(engine, anonymized.name.first, event_accumulator)
-    anonymized.name.middle = _anonymize_text(engine, anonymized.name.middle, event_accumulator)
-    anonymized.name.last = _anonymize_text(engine, anonymized.name.last, event_accumulator)
-    anonymized.name.prefix = _anonymize_text(engine, anonymized.name.prefix, event_accumulator)
-    anonymized.name.suffix = _anonymize_text(engine, anonymized.name.suffix, event_accumulator)
+    anonymized.name.first = _anonymize_text(
+        engine, anonymized.name.first, event_accumulator
+    )
+    anonymized.name.middle = _anonymize_text(
+        engine, anonymized.name.middle, event_accumulator
+    )
+    anonymized.name.last = _anonymize_text(
+        engine, anonymized.name.last, event_accumulator
+    )
+    anonymized.name.prefix = _anonymize_text(
+        engine, anonymized.name.prefix, event_accumulator
+    )
+    anonymized.name.suffix = _anonymize_text(
+        engine, anonymized.name.suffix, event_accumulator
+    )
 
     if anonymized.facility_name:
         anonymized.facility_name = _anonymize_text(
@@ -571,11 +593,17 @@ def _anonymize_coverage(
         entity_type="INSURANCE_MEMBER_ID",
         event_accumulator=event_accumulator,
     )
-    coverage.payer_name = _anonymize_text(engine, coverage.payer_name, event_accumulator)
+    coverage.payer_name = _anonymize_text(
+        engine, coverage.payer_name, event_accumulator
+    )
     coverage.payer_id = _anonymize_text(engine, coverage.payer_id, event_accumulator)
-    coverage.first_name = _anonymize_text(engine, coverage.first_name, event_accumulator)
+    coverage.first_name = _anonymize_text(
+        engine, coverage.first_name, event_accumulator
+    )
     coverage.last_name = _anonymize_text(engine, coverage.last_name, event_accumulator)
-    coverage.alt_payer_name = _anonymize_text(engine, coverage.alt_payer_name, event_accumulator)
+    coverage.alt_payer_name = _anonymize_text(
+        engine, coverage.alt_payer_name, event_accumulator
+    )
 
     # Enumerated values (gender, insurance type, subscriber relationship, payer
     # rank) are not direct identifiers and are sourced from controlled
@@ -682,7 +710,9 @@ def _synthesize_street(
         name_index = (name_index + 1) % len(_STREET_NAMES)
         suffix_index = (suffix_index + 1) % len(_STREET_SUFFIXES)
         number = ((number + 73) % 9000) + 100
-        street = f"{number} {_STREET_NAMES[name_index]} {_STREET_SUFFIXES[suffix_index]}"
+        street = (
+            f"{number} {_STREET_NAMES[name_index]} {_STREET_SUFFIXES[suffix_index]}"
+        )
 
     return street
 
@@ -825,7 +855,9 @@ def _convert_to_patient_row(
     event_accumulator: list[TransformationEvent] | None = None,
 ) -> StoragePatientRow:
     tenant_uuid = _coerce_uuid(anonymized.tenant_id, fallback=f"tenant:{document_id}")
-    facility_uuid = _coerce_uuid(anonymized.facility_id, fallback=f"facility:{document_id}")
+    facility_uuid = _coerce_uuid(
+        anonymized.facility_id, fallback=f"facility:{document_id}"
+    )
     ehr_instance_uuid: UUID | None = None
     ehr_external_id: str | None = None
     ehr_connection_status: str | None = None
@@ -852,7 +884,9 @@ def _convert_to_patient_row(
         name_last=anonymized.name.last,
         gender=(anonymized.gender or "unknown").lower(),
         status=DEFAULT_PATIENT_STATUS,
-        dob=_generalize_date_of_birth(original.dob, event_accumulator=event_accumulator),
+        dob=_generalize_date_of_birth(
+            original.dob, event_accumulator=event_accumulator
+        ),
         legal_mailing_address=legal_address,
     )
 

--- a/services/anonymizer/storage/ddl.py
+++ b/services/anonymizer/storage/ddl.py
@@ -46,7 +46,9 @@ def _load_text(path: Path, encoding: str = DEFAULT_ENCODING) -> str:
     return path.read_text(encoding=encoding)
 
 
-def load_ddl(name: str, *, directory: Path = DDL_DIRECTORY, encoding: str = DEFAULT_ENCODING) -> str:
+def load_ddl(
+    name: str, *, directory: Path = DDL_DIRECTORY, encoding: str = DEFAULT_ENCODING
+) -> str:
     """Load a DDL file from disk and return its raw contents.
 
     ``name`` may be provided with or without the ``.ddl`` suffix. ``directory``
@@ -86,7 +88,9 @@ def parse_statements(ddl_text: str) -> List[str]:
     return statements
 
 
-def load_statements(name: str, *, directory: Path = DDL_DIRECTORY, encoding: str = DEFAULT_ENCODING) -> List[str]:
+def load_statements(
+    name: str, *, directory: Path = DDL_DIRECTORY, encoding: str = DEFAULT_ENCODING
+) -> List[str]:
     """Convenience helper that loads and parses statements from ``name``."""
 
     ddl_text = load_ddl(name, directory=directory, encoding=encoding)

--- a/services/anonymizer/storage/postgres.py
+++ b/services/anonymizer/storage/postgres.py
@@ -179,13 +179,19 @@ class PostgresStorage:
                     cur.execute(query, params)
                     row = cur.fetchone()
                     if not row or row[0] is None:
-                        raise StorageError("Insert did not return a patient identifier.")
+                        raise StorageError(
+                            "Insert did not return a patient identifier."
+                        )
                     patient_id = row[0]
                 except errors.IntegrityError as exc:
                     conn.rollback()
-                    constraint = getattr(getattr(exc, "diag", None), "constraint_name", None)
+                    constraint = getattr(
+                        getattr(exc, "diag", None), "constraint_name", None
+                    )
                     detail = getattr(getattr(exc, "diag", None), "message_detail", None)
-                    message = detail or "Database constraint violated during patient insert."
+                    message = (
+                        detail or "Database constraint violated during patient insert."
+                    )
                     raise ConstraintViolationError(
                         message,
                         constraint=constraint,

--- a/services/anonymizer/storage/sqlfile.py
+++ b/services/anonymizer/storage/sqlfile.py
@@ -19,7 +19,9 @@ class SQLFileStorage:
         "-- Review the generated INSERT statements before applying them to Postgres.\n\n"
     )
 
-    def __init__(self, path: str | Path, *, append: bool = False, encoding: str = "utf-8") -> None:
+    def __init__(
+        self, path: str | Path, *, append: bool = False, encoding: str = "utf-8"
+    ) -> None:
         self._path = Path(path)
         self._append = append
         self._encoding = encoding

--- a/tests/chain_executor/test_category_cache.py
+++ b/tests/chain_executor/test_category_cache.py
@@ -7,7 +7,6 @@ import time
 from collections import OrderedDict
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any
 
 import pytest
 
@@ -181,14 +180,10 @@ def test_cache_ttl_expiry(monkeypatch: pytest.MonkeyPatch, chain_app):
 
         await chain_app._set_cached_categories("ttl-key", ("ttl",))
 
-        monkeypatch.setattr(
-            chain_app.time, "monotonic", lambda: initial_time + 0.01
-        )
+        monkeypatch.setattr(chain_app.time, "monotonic", lambda: initial_time + 0.01)
         assert await chain_app._get_cached_categories("ttl-key") == ("ttl",)
 
-        monkeypatch.setattr(
-            chain_app.time, "monotonic", lambda: initial_time + 0.06
-        )
+        monkeypatch.setattr(chain_app.time, "monotonic", lambda: initial_time + 0.06)
         assert await chain_app._get_cached_categories("ttl-key") is None
 
     asyncio.run(_run())
@@ -240,9 +235,7 @@ def test_classification_cache_max_entries_override(
     asyncio.run(_run())
 
 
-def test_classification_cache_ttl_override(
-    monkeypatch: pytest.MonkeyPatch, chain_app
-):
+def test_classification_cache_ttl_override(monkeypatch: pytest.MonkeyPatch, chain_app):
     async def _run() -> None:
         settings = chain_app.ChainExecutorSettings(
             category_cache_max_entries=4,
@@ -262,14 +255,10 @@ def test_classification_cache_ttl_override(
 
         await chain_app._set_cached_categories("ttl-key", ("ttl",))
 
-        monkeypatch.setattr(
-            chain_app.time, "monotonic", lambda: initial_time + 0.01
-        )
+        monkeypatch.setattr(chain_app.time, "monotonic", lambda: initial_time + 0.01)
         assert await chain_app._get_cached_categories("ttl-key") == ("ttl",)
 
-        monkeypatch.setattr(
-            chain_app.time, "monotonic", lambda: initial_time + 0.06
-        )
+        monkeypatch.setattr(chain_app.time, "monotonic", lambda: initial_time + 0.06)
         assert await chain_app._get_cached_categories("ttl-key") is None
 
     asyncio.run(_run())

--- a/tests/services/anonymizer/test_app_anonymize_document.py
+++ b/tests/services/anonymizer/test_app_anonymize_document.py
@@ -1,5 +1,7 @@
 """FastAPI route tests for the anonymizer service."""
 
+# ruff: noqa: E402
+
 from __future__ import annotations
 
 import abc
@@ -23,7 +25,9 @@ if str(ROOT) not in sys.path:
 if "dotenv" not in sys.modules:
     dotenv_stub = types.ModuleType("dotenv")
 
-    def load_dotenv(*_args: Any, **_kwargs: Any) -> None:  # pragma: no cover - stub helper
+    def load_dotenv(
+        *_args: Any, **_kwargs: Any
+    ) -> None:  # pragma: no cover - stub helper
         return None
 
     dotenv_stub.load_dotenv = load_dotenv
@@ -33,6 +37,7 @@ if "dotenv" not in sys.modules:
 # ---------------------------------------------------------------------------
 # Dependency stubs
 # ---------------------------------------------------------------------------
+
 
 class _FieldInfo:
     __slots__ = ("default", "alias", "default_factory")
@@ -51,6 +56,7 @@ class _FieldInfo:
 
 
 if "pydantic" not in sys.modules:
+
     class _BaseModelMeta(abc.ABCMeta):
         def __new__(mcls, name, bases, namespace, **kwargs):
             annotations: dict[str, Any] = {}
@@ -153,13 +159,17 @@ if "pydantic" not in sys.modules:
                 value = getattr(self, field_name)
                 if exclude_none and value is None:
                     continue
-                payload[key] = _serialize(value, by_alias=by_alias, exclude_none=exclude_none)
+                payload[key] = _serialize(
+                    value, by_alias=by_alias, exclude_none=exclude_none
+                )
             for key, value in self.__dict__.items():
                 if key in self._field_metadata:
                     continue
                 if exclude_none and value is None:
                     continue
-                payload[key] = _serialize(value, by_alias=by_alias, exclude_none=exclude_none)
+                payload[key] = _serialize(
+                    value, by_alias=by_alias, exclude_none=exclude_none
+                )
             return payload
 
         @classmethod
@@ -249,7 +259,9 @@ if "structlog" not in sys.modules:
 
     class _ProcessorsModule:  # pragma: no cover - stub behaviour
         @staticmethod
-        def add_log_level(logger: Any, method_name: str, event_dict: dict[str, Any]) -> dict[str, Any]:
+        def add_log_level(
+            logger: Any, method_name: str, event_dict: dict[str, Any]
+        ) -> dict[str, Any]:
             return event_dict
 
         class TimeStamper:  # pragma: no cover - stub behaviour
@@ -275,10 +287,14 @@ if "structlog" not in sys.modules:
         BoundLogger=_BoundLogger,
     )
 
-    def _configure(*args: Any, **kwargs: Any) -> None:  # pragma: no cover - stub behaviour
+    def _configure(
+        *args: Any, **kwargs: Any
+    ) -> None:  # pragma: no cover - stub behaviour
         return None
 
-    def _get_logger(*args: Any, **kwargs: Any) -> _BoundLogger:  # pragma: no cover - stub behaviour
+    def _get_logger(
+        *args: Any, **kwargs: Any
+    ) -> _BoundLogger:  # pragma: no cover - stub behaviour
         return _BoundLogger()
 
     structlog_stub.configure = _configure
@@ -352,7 +368,9 @@ if "fastapi" not in sys.modules:
             super().__init__(detail)
 
     class _Request:  # pragma: no cover - stub behaviour
-        def __init__(self, url: str = "http://test", path_params: dict[str, Any] | None = None) -> None:
+        def __init__(
+            self, url: str = "http://test", path_params: dict[str, Any] | None = None
+        ) -> None:
             self.url = types.SimpleNamespace(__str__=lambda self_ref: url, path="/")
             self.path_params = path_params or {}
 
@@ -457,7 +475,9 @@ if "starlette" not in sys.modules:
             self.headers: dict[str, str] = {}
             self.state = types.SimpleNamespace()
             self.client = types.SimpleNamespace(host=None)
-            self.url = types.SimpleNamespace(path="/", __str__=lambda self_ref: "http://test")
+            self.url = types.SimpleNamespace(
+                path="/", __str__=lambda self_ref: "http://test"
+            )
             self.method = "GET"
             self.scope: dict[str, Any] = {}
 
@@ -492,7 +512,10 @@ from services.anonymizer.models import TransformationEvent
 import services.anonymizer.app as app_module
 import services.anonymizer.service as service_module
 from services.anonymizer.firestore.client import FirestoreDataSource
-from services.anonymizer.storage.postgres import PatientRow as StoragePatientRow, StorageError
+from services.anonymizer.storage.postgres import (
+    PatientRow as StoragePatientRow,
+    StorageError,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -555,7 +578,9 @@ def test_anonymize_document_returns_summary(
     patient_id = uuid4()
     raw_phi = {"Alice Example", "MRN-12345"}
 
-    async def _fake_process_patient(collection: str, document_id: str) -> tuple[UUID, list[TransformationEvent]]:
+    async def _fake_process_patient(
+        collection: str, document_id: str
+    ) -> tuple[UUID, list[TransformationEvent]]:
         assert collection == "patients"
         assert document_id == "phi-12345"
         return patient_id, transformation_events
@@ -624,7 +649,9 @@ def test_problem_details_sanitize_document_identifier(
 ) -> None:
     """Exception handlers should expose sanitized problem details."""
 
-    async def _raiser(collection: str, document_id: str) -> tuple[UUID, list[TransformationEvent]]:
+    async def _raiser(
+        collection: str, document_id: str
+    ) -> tuple[UUID, list[TransformationEvent]]:
         raise exception_cls("boom", **exception_kwargs)
 
     monkeypatch.setattr(app_module, "process_patient", _raiser)
@@ -683,14 +710,18 @@ class _StubStorage:
 class _FailingFirestore(FirestoreDataSource):
     """Firestore stub that raises an unexpected runtime error."""
 
-    def get_patient(self, collection: str, document_id: str) -> Mapping[str, Any] | None:
+    def get_patient(
+        self, collection: str, document_id: str
+    ) -> Mapping[str, Any] | None:
         raise RuntimeError("network failure")
 
 
 class _ValidFirestore(FirestoreDataSource):
     """Firestore stub that returns a minimal valid patient document."""
 
-    def get_patient(self, collection: str, document_id: str) -> Mapping[str, Any] | None:
+    def get_patient(
+        self, collection: str, document_id: str
+    ) -> Mapping[str, Any] | None:
         return {"name": {"first": "Alice", "last": "Example"}}
 
 
@@ -718,7 +749,9 @@ def test_process_patient_wraps_fetch_errors_with_phase_details() -> None:
     _assert_phase(excinfo.value, "fetch")
 
 
-def test_process_patient_wraps_validation_errors_with_phase_details(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_process_patient_wraps_validation_errors_with_phase_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Validation errors should surface with the validation phase metadata."""
 
     storage = _StubStorage()
@@ -746,7 +779,9 @@ def test_process_patient_wraps_validation_errors_with_phase_details(monkeypatch:
     _assert_phase(excinfo.value, "validation")
 
 
-def test_process_patient_wraps_storage_errors_with_phase_details(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_process_patient_wraps_storage_errors_with_phase_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Storage failures should propagate with storage phase metadata."""
 
     storage = _StubStorage(error=StorageError("database unavailable"))
@@ -763,7 +798,9 @@ def test_process_patient_wraps_storage_errors_with_phase_details(monkeypatch: py
         return args[1]
 
     monkeypatch.setattr(service_module, "_anonymize_document", _fake_anonymize)
-    monkeypatch.setattr(service_module, "_convert_to_patient_row", lambda **_: sample_row)
+    monkeypatch.setattr(
+        service_module, "_convert_to_patient_row", lambda **_: sample_row
+    )
 
     with pytest.raises(service_module.PatientProcessingError) as excinfo:
         asyncio.run(
@@ -779,7 +816,9 @@ def test_process_patient_wraps_storage_errors_with_phase_details(monkeypatch: py
     _assert_phase(excinfo.value, "storage")
 
 
-def test_process_patient_logs_aggregate_transformation_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_process_patient_logs_aggregate_transformation_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Persisted patient log entries should only expose aggregate transformation data."""
 
     storage = _StubStorage()
@@ -822,13 +861,17 @@ def test_process_patient_logs_aggregate_transformation_summary(monkeypatch: pyte
         return document
 
     monkeypatch.setattr(service_module, "_anonymize_document", _fake_anonymize)
-    monkeypatch.setattr(service_module, "_convert_to_patient_row", lambda **_: sample_row)
+    monkeypatch.setattr(
+        service_module, "_convert_to_patient_row", lambda **_: sample_row
+    )
 
     class _CapturingLogger:
         def __init__(self) -> None:
             self.records: list[dict[str, Any]] = []
 
-        def bind(self, **_kwargs: Any) -> "_CapturingLogger":  # pragma: no cover - passthrough
+        def bind(
+            self, **_kwargs: Any
+        ) -> "_CapturingLogger":  # pragma: no cover - passthrough
             return self
 
         def info(self, message: str, **kwargs: Any) -> None:
@@ -867,7 +910,10 @@ def test_process_patient_logs_aggregate_transformation_summary(monkeypatch: pyte
 
     logged_summary = persisted_log["kwargs"].get("transformation_summary")
     assert logged_summary == expected_summary
-    assert persisted_log["kwargs"].get("total_transformations") == expected_summary["total_transformations"]
+    assert (
+        persisted_log["kwargs"].get("total_transformations")
+        == expected_summary["total_transformations"]
+    )
     assert (
         persisted_log["kwargs"].get("transformation_actions")
         == expected_summary["actions"]
@@ -877,4 +923,3 @@ def test_process_patient_logs_aggregate_transformation_summary(monkeypatch: pyte
         == expected_summary["entities"]
     )
     assert "Alice" not in repr(persisted_log)
-

--- a/tests/services/anonymizer/test_firestore_client.py
+++ b/tests/services/anonymizer/test_firestore_client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+# ruff: noqa: E402
+
 from pathlib import Path
 import sys
 import types
@@ -27,15 +29,21 @@ if "presidio_analyzer" not in sys.modules:
 
     class _AnalyzerEngine:
         def __init__(self) -> None:
-            self.registry = types.SimpleNamespace(add_recognizer=lambda *args, **kwargs: None)
+            self.registry = types.SimpleNamespace(
+                add_recognizer=lambda *args, **kwargs: None
+            )
 
     class _Pattern:
-        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - simple stub
+        def __init__(
+            self, *args: Any, **kwargs: Any
+        ) -> None:  # pragma: no cover - simple stub
             self.args = args
             self.kwargs = kwargs
 
     class _PatternRecognizer:
-        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - simple stub
+        def __init__(
+            self, *args: Any, **kwargs: Any
+        ) -> None:  # pragma: no cover - simple stub
             self.args = args
             self.kwargs = kwargs
 
@@ -62,7 +70,6 @@ from services.anonymizer.firestore.client import (
     ENV_FIXTURE_DIRECTORY,
     ENV_PROJECT_ID,
     MODE_CREDENTIALS,
-    MODE_FIXTURES,
 )
 
 
@@ -76,7 +83,9 @@ class _StubDocumentSnapshot:
 
 
 class _StubDocumentReference:
-    def __init__(self, *, snapshot: _StubDocumentSnapshot | None, error: Exception | None = None) -> None:
+    def __init__(
+        self, *, snapshot: _StubDocumentSnapshot | None, error: Exception | None = None
+    ) -> None:
         self._snapshot = snapshot
         self._error = error
 
@@ -102,10 +111,17 @@ class _StubCollectionReference:
 
 
 class _StubFirestoreClient:
-    def __init__(self, *, snapshot: _StubDocumentSnapshot | None = None, error: Exception | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        snapshot: _StubDocumentSnapshot | None = None,
+        error: Exception | None = None,
+    ) -> None:
         self.collection_calls: list[str] = []
         self._collection = _StubCollectionReference()
-        self._collection.set_document(_StubDocumentReference(snapshot=snapshot, error=error))
+        self._collection.set_document(
+            _StubDocumentReference(snapshot=snapshot, error=error)
+        )
 
     def collection(self, name: str) -> _StubCollectionReference:
         self.collection_calls.append(name)
@@ -128,13 +144,17 @@ def test_fixture_data_source_returns_none_for_missing_patient() -> None:
 
 
 @pytest.mark.parametrize("collection", ["clinicians", "", "Facilities"])
-def test_fixture_data_source_returns_none_for_mismatched_collection(collection: str) -> None:
+def test_fixture_data_source_returns_none_for_mismatched_collection(
+    collection: str,
+) -> None:
     data_source = FixtureFirestoreDataSource()
 
     assert data_source.get_patient(collection, "xpF51IBED5TOKMPJamWo") is None
 
 
-def test_create_firestore_data_source_defaults_to_fixture_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_create_firestore_data_source_defaults_to_fixture_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.delenv(ENV_DATA_SOURCE, raising=False)
     monkeypatch.delenv(ENV_FIXTURE_DIRECTORY, raising=False)
 
@@ -143,7 +163,9 @@ def test_create_firestore_data_source_defaults_to_fixture_mode(monkeypatch: pyte
     assert isinstance(data_source, FixtureFirestoreDataSource)
 
 
-def test_create_firestore_data_source_uses_custom_fixture_directory(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_create_firestore_data_source_uses_custom_fixture_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     fixture = tmp_path / "patients"
     fixture.mkdir()
     payload = fixture / "example.json"
@@ -157,14 +179,18 @@ def test_create_firestore_data_source_uses_custom_fixture_directory(monkeypatch:
     assert isinstance(data_source, FixtureFirestoreDataSource)
 
 
-def test_create_firestore_data_source_validates_fixture_directory(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_create_firestore_data_source_validates_fixture_directory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv(ENV_FIXTURE_DIRECTORY, "/does/not/exist")
 
     with pytest.raises(FirestoreConfigurationError):
         create_firestore_data_source()
 
 
-def test_create_firestore_data_source_with_credentials_requires_path(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_create_firestore_data_source_with_credentials_requires_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv(ENV_DATA_SOURCE, MODE_CREDENTIALS)
     monkeypatch.delenv(ENV_CREDENTIALS, raising=False)
 
@@ -194,7 +220,9 @@ def test_create_firestore_data_source_with_credentials_returns_client(
     assert data_source.project_id == "example-project"
 
 
-def test_create_firestore_data_source_with_unknown_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_create_firestore_data_source_with_unknown_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv(ENV_DATA_SOURCE, "unknown")
 
     with pytest.raises(FirestoreConfigurationError):
@@ -220,7 +248,9 @@ def test_credentialed_firestore_data_source_returns_document(tmp_path: Path) -> 
     assert client.collection_calls == ["patients"]
 
 
-def test_credentialed_firestore_data_source_returns_none_for_missing_document(tmp_path: Path) -> None:
+def test_credentialed_firestore_data_source_returns_none_for_missing_document(
+    tmp_path: Path,
+) -> None:
     credentials_path = tmp_path / "credentials.json"
     credentials_path.write_text("{}", encoding="utf-8")
 

--- a/tests/services/anonymizer/test_logging_utils.py
+++ b/tests/services/anonymizer/test_logging_utils.py
@@ -1,5 +1,7 @@
 """Tests for anonymizer logging guardrails."""
 
+# ruff: noqa: E402
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -49,7 +51,9 @@ class _BaseModelStub:
     def __init__(self, payload: dict[str, object]) -> None:
         self._payload = payload
 
-    def model_dump(self, mode: str = "python") -> dict[str, object]:  # pragma: no cover - simple stub
+    def model_dump(
+        self, mode: str = "python"
+    ) -> dict[str, object]:  # pragma: no cover - simple stub
         return dict(self._payload)
 
 
@@ -86,7 +90,9 @@ def test_scrub_for_logging_summarizes_sequences() -> None:
 
 
 def test_scrub_for_logging_handles_dataclasses() -> None:
-    record = DummyRow(tenant_id=uuid4(), status="inactive", name_first="Given", name_last="Family")
+    record = DummyRow(
+        tenant_id=uuid4(), status="inactive", name_first="Given", name_last="Family"
+    )
 
     sanitized = scrub_for_logging(record)
 

--- a/tests/services/anonymizer/test_presidio_engine.py
+++ b/tests/services/anonymizer/test_presidio_engine.py
@@ -1,5 +1,7 @@
 """Unit tests for the Presidio anonymizer engine."""
 
+# ruff: noqa: E402
+
 from __future__ import annotations
 
 from collections.abc import Iterable
@@ -55,7 +57,9 @@ if "presidio_analyzer" not in sys.modules:
             return _Registry()
 
     class RecognizerResult:  # pragma: no cover - stub
-        def __init__(self, entity_type: str, start: int, end: int, score: float, **_: object) -> None:
+        def __init__(
+            self, entity_type: str, start: int, end: int, score: float, **_: object
+        ) -> None:
             self.entity_type = entity_type
             self.start = start
             self.end = end

--- a/tests/services/anonymizer/test_reporting.py
+++ b/tests/services/anonymizer/test_reporting.py
@@ -1,5 +1,7 @@
 """Tests for anonymizer reporting helpers."""
 
+# ruff: noqa: E402
+
 from __future__ import annotations
 
 import importlib.util
@@ -122,4 +124,3 @@ def test_summarize_transformations_includes_metadata_notes() -> None:
     serialized = json.dumps(summary)
     assert "Safe Harbor" not in serialized
     assert "Suppressed name" not in serialized
-

--- a/tests/services/anonymizer/test_service_configuration.py
+++ b/tests/services/anonymizer/test_service_configuration.py
@@ -1,5 +1,7 @@
 """Tests for anonymizer service configuration helpers."""
 
+# ruff: noqa: E402
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -174,7 +176,9 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(service.ENV_ANONYMIZER_HASH_LENGTH, raising=False)
 
 
-def test_presidio_config_defaults_when_env_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_presidio_config_defaults_when_env_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     _clear_env(monkeypatch)
 
     config = service._create_presidio_config_from_env()
@@ -185,7 +189,9 @@ def test_presidio_config_defaults_when_env_absent(monkeypatch: pytest.MonkeyPatc
     assert config.hash_length == default.hash_length
 
 
-def test_presidio_config_overrides_from_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_presidio_config_overrides_from_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     _clear_env(monkeypatch)
     monkeypatch.setenv(service.ENV_ANONYMIZER_HASH_SECRET, "override-secret")
     monkeypatch.setenv(service.ENV_ANONYMIZER_HASH_PREFIX, "override-prefix")
@@ -198,7 +204,9 @@ def test_presidio_config_overrides_from_environment(monkeypatch: pytest.MonkeyPa
     assert config.hash_length == 24
 
 
-def test_configure_service_passes_environment_config(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_configure_service_passes_environment_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     _clear_env(monkeypatch)
     monkeypatch.setenv(service.ENV_ANONYMIZER_HASH_SECRET, "configured-secret")
 

--- a/tests/services/anonymizer/test_service_dob_generalization.py
+++ b/tests/services/anonymizer/test_service_dob_generalization.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+# ruff: noqa: E402
+
 from datetime import date
 from pathlib import Path
 import sys
@@ -210,7 +212,10 @@ def test_generalizes_birth_date_for_patients_younger_than_90() -> None:
     )
 
     assert row.dob == date(dob.year, 1, 1)
-    assert any(event.action == "generalize" and event.entity_type == "PATIENT_DOB" for event in events)
+    assert any(
+        event.action == "generalize" and event.entity_type == "PATIENT_DOB"
+        for event in events
+    )
 
 
 def test_suppresses_birth_date_for_patients_aged_90_or_older() -> None:
@@ -226,7 +231,10 @@ def test_suppresses_birth_date_for_patients_aged_90_or_older() -> None:
     )
 
     assert row.dob is None
-    assert any(event.action == "suppress" and event.entity_type == "PATIENT_DOB" for event in events)
+    assert any(
+        event.action == "suppress" and event.entity_type == "PATIENT_DOB"
+        for event in events
+    )
 
 
 def test_patient_row_generalizes_year_only_for_age_eighty_nine() -> None:

--- a/tests/services/anonymizer/test_service_transformation_events.py
+++ b/tests/services/anonymizer/test_service_transformation_events.py
@@ -1,5 +1,7 @@
 """Unit tests ensuring anonymizer service accumulates transformation events."""
 
+# ruff: noqa: E402
+
 from __future__ import annotations
 
 from collections.abc import Mapping
@@ -347,7 +349,9 @@ def test_accumulates_address_events_without_leaking_phi() -> None:
         "PATIENT_ADDRESS_CITY",
         "PATIENT_ADDRESS_POSTAL_CODE",
     }
-    captured = {event.entity_type for event in events if event.entity_type in address_entities}
+    captured = {
+        event.entity_type for event in events if event.entity_type in address_entities
+    }
     assert captured == address_entities
 
     synthesized_address = anonymized.coverages[0].address
@@ -363,7 +367,9 @@ def test_accumulates_address_events_without_leaking_phi() -> None:
     assert synthesized_address.country == "US"
 
     synthesized_events = {
-        event.entity_type: event for event in events if event.entity_type in address_entities
+        event.entity_type: event
+        for event in events
+        if event.entity_type in address_entities
     }
     for entity in address_entities:
         event = synthesized_events[entity]
@@ -373,8 +379,13 @@ def test_accumulates_address_events_without_leaking_phi() -> None:
         assert "Metropolis" not in event.surrogate
         assert "10101" not in event.surrogate
 
-    assert synthesized_address.address_line1 in synthesized_events["PATIENT_ADDRESS_STREET"].surrogate
-    assert synthesized_address.city in synthesized_events["PATIENT_ADDRESS_CITY"].surrogate
+    assert (
+        synthesized_address.address_line1
+        in synthesized_events["PATIENT_ADDRESS_STREET"].surrogate
+    )
+    assert (
+        synthesized_address.city in synthesized_events["PATIENT_ADDRESS_CITY"].surrogate
+    )
     assert (
         synthesized_address.postal_code
         in synthesized_events["PATIENT_ADDRESS_POSTAL_CODE"].surrogate
@@ -391,9 +402,9 @@ def test_identifier_fallback_hashes_and_emits_events() -> None:
         coverages=[FirestoreCoverage(member_id="MEMBER-0001")],
     )
 
-    secret = os.environ.get("ANONYMIZER_IDENTIFIER_HASH_SECRET", "ai-chat-ehr-anonymizer").encode(
-        "utf-8"
-    )
+    secret = os.environ.get(
+        "ANONYMIZER_IDENTIFIER_HASH_SECRET", "ai-chat-ehr-anonymizer"
+    ).encode("utf-8")
 
     def _expected(value: str) -> str:
         return hmac.new(secret, value.encode("utf-8"), hashlib.sha256).hexdigest()
@@ -420,16 +431,26 @@ def test_identifier_fallback_hashes_and_emits_events() -> None:
     assert captured == set(expected_hashes)
     for event in events:
         assert event.action == "pseudonymize"
-        assert event.surrogate == "Applied HMAC pseudonymization fallback for identifier."
+        assert (
+            event.surrogate == "Applied HMAC pseudonymization fallback for identifier."
+        )
 
     document_id = "doc-42"
-    facility_uuid_first = _coerce_uuid(anonymized.facility_id, fallback=f"facility:{document_id}")
-    facility_uuid_second = _coerce_uuid(anonymized.facility_id, fallback=f"facility:{document_id}")
+    facility_uuid_first = _coerce_uuid(
+        anonymized.facility_id, fallback=f"facility:{document_id}"
+    )
+    facility_uuid_second = _coerce_uuid(
+        anonymized.facility_id, fallback=f"facility:{document_id}"
+    )
     assert facility_uuid_first == facility_uuid_second
     assert facility_uuid_first == uuid5(NAMESPACE_URL, anonymized.facility_id.strip())
 
-    tenant_uuid_first = _coerce_uuid(anonymized.tenant_id, fallback=f"tenant:{document_id}")
-    tenant_uuid_second = _coerce_uuid(anonymized.tenant_id, fallback=f"tenant:{document_id}")
+    tenant_uuid_first = _coerce_uuid(
+        anonymized.tenant_id, fallback=f"tenant:{document_id}"
+    )
+    tenant_uuid_second = _coerce_uuid(
+        anonymized.tenant_id, fallback=f"tenant:{document_id}"
+    )
     assert tenant_uuid_first == tenant_uuid_second
     assert tenant_uuid_first == uuid5(NAMESPACE_URL, anonymized.tenant_id.strip())
 
@@ -441,7 +462,11 @@ def test_accumulates_coverage_identifier_events_without_leaking_phi() -> None:
             "Smith": ("anon-last", "token-last", "PATIENT_LAST_NAME"),
             "M-123": ("anon-member", "token-member", "COVERAGE_MEMBER_ID"),
             "PAYER-001": ("anon-payer", "token-payer", "COVERAGE_PAYER_ID"),
-            "Acme Health": ("anon-payer-name", "token-payer-name", "COVERAGE_PAYER_NAME"),
+            "Acme Health": (
+                "anon-payer-name",
+                "token-payer-name",
+                "COVERAGE_PAYER_NAME",
+            ),
         }
     )
     document = _build_document()
@@ -461,7 +486,11 @@ def test_accumulates_coverage_identifier_events_without_leaking_phi() -> None:
         "COVERAGE_PAYER_ID",
         "COVERAGE_PAYER_NAME",
     }
-    captured = {event.entity_type for event in events if event.entity_type in identifier_entities}
+    captured = {
+        event.entity_type
+        for event in events
+        if event.entity_type in identifier_entities
+    }
     assert captured == identifier_entities
 
     originals = {
@@ -574,12 +603,14 @@ def test_anonymize_coverage_is_deterministic_for_phi_fields() -> None:
     first_surrogates = {
         (event.entity_type, event.surrogate)
         for event in first_events
-        if event.entity_type in {"COVERAGE_MEMBER_ID", "COVERAGE_PAYER_NAME", "COVERAGE_PAYER_ID"}
+        if event.entity_type
+        in {"COVERAGE_MEMBER_ID", "COVERAGE_PAYER_NAME", "COVERAGE_PAYER_ID"}
     }
     second_surrogates = {
         (event.entity_type, event.surrogate)
         for event in second_events
-        if event.entity_type in {"COVERAGE_MEMBER_ID", "COVERAGE_PAYER_NAME", "COVERAGE_PAYER_ID"}
+        if event.entity_type
+        in {"COVERAGE_MEMBER_ID", "COVERAGE_PAYER_NAME", "COVERAGE_PAYER_ID"}
     }
     assert first_surrogates == second_surrogates
 
@@ -742,11 +773,17 @@ def test_extract_address_handles_missing_state() -> None:
         "PATIENT_ADDRESS_CITY",
         "PATIENT_ADDRESS_POSTAL_CODE",
     }
-    captured = {event.entity_type for event in events if event.entity_type in synthesized_entities}
+    captured = {
+        event.entity_type
+        for event in events
+        if event.entity_type in synthesized_entities
+    }
     assert captured == synthesized_entities
 
     synthesized_events = {
-        event.entity_type: event for event in events if event.entity_type in synthesized_entities
+        event.entity_type: event
+        for event in events
+        if event.entity_type in synthesized_entities
     }
     for entity in synthesized_entities:
         event = synthesized_events[entity]
@@ -755,8 +792,13 @@ def test_extract_address_handles_missing_state() -> None:
         assert "Springfield" not in event.surrogate
         assert "99999" not in event.surrogate
 
-    assert synthesized_address.address_line1 in synthesized_events["PATIENT_ADDRESS_STREET"].surrogate
-    assert synthesized_address.city in synthesized_events["PATIENT_ADDRESS_CITY"].surrogate
+    assert (
+        synthesized_address.address_line1
+        in synthesized_events["PATIENT_ADDRESS_STREET"].surrogate
+    )
+    assert (
+        synthesized_address.city in synthesized_events["PATIENT_ADDRESS_CITY"].surrogate
+    )
     assert (
         synthesized_address.postal_code
         in synthesized_events["PATIENT_ADDRESS_POSTAL_CODE"].surrogate

--- a/tests/services/anonymizer/test_storage_sqlfile.py
+++ b/tests/services/anonymizer/test_storage_sqlfile.py
@@ -1,5 +1,7 @@
 """Tests for the SQL file storage backend used by the anonymizer."""
 
+# ruff: noqa: E402
+
 from __future__ import annotations
 
 from pathlib import Path


### PR DESCRIPTION
## Summary
- apply Ruff formatting across the anonymizer service and test modules
- move environment loading in the anonymizer package to keep imports at the top of the module
- add targeted Ruff suppressions and remove unused imports flagged by linting

## Testing
- ruff format --check
- ruff check

------
https://chatgpt.com/codex/tasks/task_e_68dccd37be5c83308306bdd1a058bb88