### PR TITLE
Clarify generalization metadata docstring

### DIFF
--- a/services/anonymizer/reporting.py
+++ b/services/anonymizer/reporting.py
@@ -52,10 +52,10 @@ def summarize_transformations(
         ``action`` (or ``strategy``) field describing how the entity was
         anonymized.
 
-        generalization_metadata:
-            Optional mapping keyed by entity type providing additional
-            anonymization metadata.  Only the count of ``notes`` entries is
-            surfaced in the returned summary to avoid exposing PHI.
+    generalization_metadata, optional:
+        Optional second argument mapping keyed by entity type providing
+        additional anonymization metadata.  Only the count of ``notes`` entries
+        is surfaced in the returned summary to avoid exposing PHI.
 
     Returns
     -------


### PR DESCRIPTION
## Summary
- align the generalization_metadata parameter documentation with the transformations entry
- clarify that generalization_metadata is an optional second argument providing anonymization metadata

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcceca3f28833081de7bd3a47b70a7