### PR TITLE
Document default Presidio hash secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,8 +114,9 @@ ANONYMIZER_STORAGE_MODE=database
 # Filesystem path where INSERT statements are written when the storage mode is
 # set to "sqlfile".
 ANONYMIZER_STORAGE_SQL_PATH=anonymizer_dry_run.sql
-# Secret value used by the Presidio anonymizer when hashing identifiers. Leave
-# unset to use Presidio's default secret.
+# Secret value used by the Presidio anonymizer when hashing identifiers. When
+# omitted, the app keeps the bundled default ("ai-chat-ehr-safe-harbor") defined
+# in PresidioEngineConfig. Set this value to override the default secret.
 ANONYMIZER_HASH_SECRET=
 # Prefix applied to hashed identifier values. Leave unset to rely on Presidio's
 # default prefix.


### PR DESCRIPTION
## Summary
- clarify that ANONYMIZER_HASH_SECRET defaults to the bundled PresidioEngineConfig value when unset
- note that setting the variable overrides the default secret

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd453bbd08330aa83436c23e8030b