### PR TITLE
Handle whitespace in Firestore data source mode selection

### DIFF
--- a/services/anonymizer/firestore/client.py
+++ b/services/anonymizer/firestore/client.py
@@ -166,7 +166,12 @@ def _load_fixture_paths_from_env() -> Iterable[Path] | None:
 def create_firestore_data_source() -> FirestoreDataSource:
     """Return a configured Firestore data source based on environment variables."""
 
-    mode = os.getenv(ENV_DATA_SOURCE, MODE_FIXTURES).lower()
+    raw_mode = os.getenv(ENV_DATA_SOURCE)
+    if raw_mode is None:
+        mode = MODE_FIXTURES
+    else:
+        stripped_mode = raw_mode.strip()
+        mode = stripped_mode.lower() if stripped_mode else MODE_FIXTURES
 
     if mode == MODE_FIXTURES:
         fixture_paths = _load_fixture_paths_from_env()


### PR DESCRIPTION
## Summary
- strip whitespace before normalizing the anonymizer Firestore data source mode
- retain the fixtures default when the environment variable is unset or blank

## Testing
- pytest tests/services/anonymizer/test_firestore_client.py

------
https://chatgpt.com/codex/tasks/task_e_68dcd463f8888330b7a0b4af95ed7444