### PR TITLE
Handle whitespace in Firestore data source env variable

### DIFF
--- a/services/anonymizer/firestore/client.py
+++ b/services/anonymizer/firestore/client.py
@@ -166,7 +166,8 @@ def _load_fixture_paths_from_env() -> Iterable[Path] | None:
 def create_firestore_data_source() -> FirestoreDataSource:
     """Return a configured Firestore data source based on environment variables."""
 
-    mode = os.getenv(ENV_DATA_SOURCE, MODE_FIXTURES).lower()
+    raw_mode = os.getenv(ENV_DATA_SOURCE)
+    mode = (raw_mode.strip() if raw_mode is not None else MODE_FIXTURES).lower()
 
     if mode == MODE_FIXTURES:
         fixture_paths = _load_fixture_paths_from_env()

--- a/tests/services/anonymizer/test_firestore_client.py
+++ b/tests/services/anonymizer/test_firestore_client.py
@@ -163,6 +163,19 @@ def test_create_firestore_data_source_defaults_to_fixture_mode(
     assert isinstance(data_source, FixtureFirestoreDataSource)
 
 
+def test_create_firestore_data_source_trims_env_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(ENV_DATA_SOURCE, "  fixtures  ")
+
+    data_source = create_firestore_data_source()
+
+    try:
+        assert isinstance(data_source, FixtureFirestoreDataSource)
+    finally:
+        monkeypatch.delenv(ENV_DATA_SOURCE, raising=False)
+
+
 def test_create_firestore_data_source_uses_custom_fixture_directory(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- trim whitespace from ENV_DATA_SOURCE before determining the firestore data source
- add a regression test covering whitespace-padded fixture mode values

## Testing
- poetry run pytest tests/services/anonymizer/test_firestore_client.py

------
https://chatgpt.com/codex/tasks/task_e_68dcd47cc0ec83308332584a880bca43