### PR TITLE
Fix ruff formatting in patient context tests

### DIFF
--- a/tests/patient_context/test_app.py
+++ b/tests/patient_context/test_app.py
@@ -101,7 +101,9 @@ async def test_read_patient_record(client: AsyncClient) -> None:
 
     payload = response.json()
     assert payload["demographics"]["patientId"] == "123456"
-    assert payload["medications"], "Expected medications to be present in patient record"
+    assert payload["medications"], (
+        "Expected medications to be present in patient record"
+    )
     assert payload["encounters"], "Expected encounters to be present in patient record"
 
 


### PR DESCRIPTION
## Summary
- apply `ruff format` fixes to `tests/patient_context/test_app.py` to satisfy style checks

## Testing
- `poetry run ruff check`


------
https://chatgpt.com/codex/tasks/task_e_68dcd807e4e08330805a8853ae90e09a