### PR TITLE
Clarify hyphenation in anonymizer summary docstring

### DIFF
--- a/services/anonymizer/reporting.py
+++ b/services/anonymizer/reporting.py
@@ -35,11 +35,11 @@ def summarize_transformations(
     transformations: Iterable[Mapping[str, Any]],
     generalization_metadata: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Aggregate anonymization transformations into a JSON friendly summary.
+    """Aggregate anonymization transformations into a JSON-friendly summary.
 
     The anonymizer may record individual transformation events that include
     sensitive values such as the original piece of PHI.  This helper collapses
-    those events into high level counts grouped by entity type and action
+    those events into high-level counts grouped by entity type and action
     ensuring that the returned payload is JSON serializable and does not
     include any raw PHI strings.
 


### PR DESCRIPTION
## Summary
- ensure the anonymizer reporting summary docstring consistently uses hyphenated compound modifiers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd93f583083308b288bb82dc4175b