### PR TITLE
Clarify docstring for category value helper

### DIFF
--- a/services/prompt_catalog/repositories.py
+++ b/services/prompt_catalog/repositories.py
@@ -142,7 +142,7 @@ class PromptRepository:
         return categories
 
     def _iterate_category_values(self, value: Any) -> Iterable[str]:
-        """Yield raw category values from ``value`` regardless of structure."""
+        """Return raw category values from ``value`` regardless of structure."""
 
         if value is None:
             return []


### PR DESCRIPTION
## Summary
- update the `_iterate_category_values` docstring to describe the function as returning raw category values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd95bae488330a7706254993dd720