### PR TITLE
Trim whitespace from patient context category filters

### DIFF
--- a/services/patient_context/mappers.py
+++ b/services/patient_context/mappers.py
@@ -130,7 +130,10 @@ def filter_context_by_categories(
     for slug in categories:
         if not isinstance(slug, str):
             continue
-        candidate = _CATEGORY_SLUG_MAP.get(slug.casefold())
+        cleaned_slug = slug.strip()
+        if not cleaned_slug:
+            continue
+        candidate = _CATEGORY_SLUG_MAP.get(cleaned_slug.casefold())
         if not candidate or candidate in seen:
             continue
         resolved.append(candidate)

--- a/tests/patient_context/test_app.py
+++ b/tests/patient_context/test_app.py
@@ -147,3 +147,18 @@ async def test_read_patient_context_with_unknown_category(client: AsyncClient) -
     assert payload["medications"] == []
     assert payload["labResults"] == []
     assert payload["plan"].startswith("Continue lisinopril")
+
+
+@pytest.mark.anyio("asyncio")
+async def test_read_patient_context_with_whitespace_categories(
+    client: AsyncClient,
+) -> None:
+    response = await client.get(
+        "/patients/123456/context",
+        params=[("categories", "  labs  "), ("categories", "\nnotes\t")],
+    )
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["labResults"], "Expected lab results when whitespace is trimmed"
+    assert payload["clinicalNotes"], "Expected clinical notes when whitespace is trimmed"


### PR DESCRIPTION
## Summary
- trim leading and trailing whitespace from category filter values before resolving slug mappings
- add an API test ensuring whitespace-padded categories still return their data

## Testing
- pytest tests/patient_context/test_app.py -k whitespace

------
https://chatgpt.com/codex/tasks/task_e_68dcd956e66c833098b39b97712b648a