### PR TITLE
Add limit truncation test for prompt search

### DIFF
--- a/tests/prompt_catalog/test_repositories.py
+++ b/tests/prompt_catalog/test_repositories.py
@@ -43,6 +43,23 @@ async def test_search_prompts_zero_limit_returns_empty_list() -> None:
 
 
 @pytest.mark.anyio("asyncio")
+async def test_search_prompts_limit_truncates_in_insertion_order() -> None:
+    prompts = [
+        ChatPrompt(
+            title=f"Prompt {index}",
+            template="Hello",
+            metadata={"id": f"prompt-{index}"},
+        )
+        for index in range(5)
+    ]
+    repository = PromptRepository(prompts)
+
+    results = await repository.search_prompts(limit=3)
+
+    assert results == prompts[:3]
+
+
+@pytest.mark.anyio("asyncio")
 async def test_get_prompt_accepts_string_identifier() -> None:
     repository = _create_repository()
 


### PR DESCRIPTION
## Summary
- add a regression test ensuring prompt search respects the requested limit
- verify that search results remain in insertion order when truncated

## Testing
- `pytest tests/prompt_catalog/test_repositories.py` *(fails: ModuleNotFoundError: No module named 'shared')*

------
https://chatgpt.com/codex/tasks/task_e_68dce2eb2d3083309e40e744cfc4a854