### PR TITLE
Add generator service Dockerfile and compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,18 @@ services:
     ports:
       - "8004:8004"
 
+  generator:
+    image: ai-chat-ehr-generator:latest
+    build:
+      context: .
+      dockerfile: services/generator/Dockerfile
+      args:
+        BASE_IMAGE: ${BASE_IMAGE:-ai-chat-ehr-base:latest}
+    env_file:
+      - .env
+    ports:
+      - "8005:8005"
+
   redis:
     image: redis:7-alpine
     ports:

--- a/services/generator/Dockerfile
+++ b/services/generator/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.5
+
+ARG BASE_IMAGE=ai-chat-ehr-base:latest
+FROM ${BASE_IMAGE} AS runtime
+
+WORKDIR /app
+
+COPY shared ./shared
+COPY services/generator ./services/generator
+
+EXPOSE 8005
+
+CMD ["uvicorn", "services.generator.main:app", "--host", "0.0.0.0", "--port", "8005"]


### PR DESCRIPTION
## Summary
- add a Dockerfile for the generator service using the shared base image pattern
- register the generator container in docker-compose with environment wiring and port 8005

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd4c78ec08833085598c1c9cb103ab