### PR TITLE
Align generator package initialization

### DIFF
--- a/services/generator/__init__.py
+++ b/services/generator/__init__.py
@@ -1,5 +1,13 @@
 """Generator service package exposing the FastAPI application factory."""
 
+from pathlib import Path
+
+from dotenv import load_dotenv
+
 from .app import app, get_app
 
-__all__ = ["app", "get_app"]
+__all__ = ["__version__", "app", "get_app"]
+
+__version__ = "0.1.0"
+
+load_dotenv(Path(__file__).resolve().parents[2] / ".env", override=False)


### PR DESCRIPTION
## Summary
- load environment configuration in the generator service the same way as other services
- export the generator service public API explicitly via `__all__`
- add a `__version__` constant for parity with sibling packages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd4d095240833086c6e8aaf7d51502