### PR TITLE
Add generator logging setup and scrubbing utilities

### DIFF
--- a/services/generator/__init__.py
+++ b/services/generator/__init__.py
@@ -4,9 +4,17 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
+from .observability import cli_request_context, logger, scrub_for_logging
 from .app import app, get_app
 
-__all__ = ["__version__", "app", "get_app"]
+__all__ = [
+    "__version__",
+    "app",
+    "cli_request_context",
+    "get_app",
+    "logger",
+    "scrub_for_logging",
+]
 
 __version__ = "0.1.0"
 

--- a/services/generator/app.py
+++ b/services/generator/app.py
@@ -5,20 +5,20 @@ from __future__ import annotations
 from fastapi import FastAPI
 
 from shared.http.errors import register_exception_handlers
-from shared.observability.logger import configure_logging
 from shared.observability.middleware import (
     CorrelationIdMiddleware,
     RequestTimingMiddleware,
 )
 
-SERVICE_NAME = "generator"
-
-configure_logging(service_name=SERVICE_NAME)
+from .constants import SERVICE_NAME
+from .observability import logger
 
 app = FastAPI(title="Generator Service")
 app.add_middleware(RequestTimingMiddleware)
 app.add_middleware(CorrelationIdMiddleware)
 register_exception_handlers(app)
+
+logger.bind(component="fastapi").debug("Generator application configured")
 
 
 @app.get("/health", tags=["health"])

--- a/services/generator/constants.py
+++ b/services/generator/constants.py
@@ -1,0 +1,7 @@
+"""Constants for the generator service."""
+
+from __future__ import annotations
+
+SERVICE_NAME = "generator"
+
+__all__ = ["SERVICE_NAME"]

--- a/services/generator/observability.py
+++ b/services/generator/observability.py
@@ -1,0 +1,109 @@
+"""Observability helpers shared by the generator service."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence, Set
+from contextlib import contextmanager
+from dataclasses import asdict, is_dataclass
+from typing import Any, Iterator
+
+from shared.observability import configure_logging, get_logger, request_context
+
+from .constants import SERVICE_NAME
+
+configure_logging(service_name=SERVICE_NAME)
+
+logger = get_logger("services.generator")
+
+
+@contextmanager
+def cli_request_context(
+    *, request_id: str | None = None, **extra: Any
+) -> Iterator[str]:
+    """Bind a request identifier for CLI-driven workflows.
+
+    The helper ensures multi-step CLI operations attach correlation metadata to
+    generated log entries so downstream processors can stitch together related
+    events.
+    """
+
+    cli_context = {"channel": "cli"}
+    cli_context.update(extra)
+
+    with request_context(request_id=request_id, **cli_context) as bound_request_id:
+        yield bound_request_id
+
+
+def scrub_for_logging(
+    payload: Any,
+    *,
+    allow_keys: Iterable[str] | None = None,
+    max_depth: int = 3,
+    max_items: int = 5,
+) -> Any:
+    """Return a sanitized representation of ``payload`` safe for log emission.
+
+    Strings and other potentially sensitive scalar values are replaced with a
+    ``"[redacted]"`` placeholder unless explicitly opted in through
+    ``allow_keys``.  Nested mappings, dataclasses, and Pydantic models are
+    traversed up to ``max_depth`` levels to avoid unbounded recursion.  Sequence
+    types are summarized to the first ``max_items`` elements to keep log payloads
+    compact while still providing useful debugging context.
+    """
+
+    allowed = set(allow_keys or set())
+
+    def _scrub(value: Any, depth: int) -> Any:
+        if depth <= 0:
+            return "[scrubbed]"
+
+        if isinstance(value, Mapping):
+            sanitized: dict[str, Any] = {}
+            for key, item in value.items():
+                key_str = str(key)
+                if key_str in allowed:
+                    sanitized[key_str] = item
+                else:
+                    sanitized[key_str] = _scrub(item, depth - 1)
+            return sanitized
+
+        if is_dataclass(value):
+            return _scrub(asdict(value), depth)
+
+        if hasattr(value, "model_dump"):
+            dump = value.model_dump  # type: ignore[attr-defined]
+            try:
+                mapping = dump(mode="python")  # type: ignore[call-arg]
+            except TypeError:  # pragma: no cover - older signatures
+                mapping = dump()
+            if isinstance(mapping, Mapping):
+                return _scrub(mapping, depth)
+
+        if isinstance(value, str):
+            return value if not value else "[redacted]"
+
+        if isinstance(value, bytes):
+            return "[bytes]"
+
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            sample = [_scrub(item, depth - 1) for item in list(value)[:max_items]]
+            if isinstance(value, tuple):
+                return tuple(sample)
+            return sample
+
+        if isinstance(value, Set):
+            sample = [_scrub(item, depth - 1) for item in list(value)[:max_items]]
+            try:
+                return type(value)(sample)
+            except TypeError:  # pragma: no cover - fallback for unhashable payloads
+                return sample
+
+        if isinstance(value, (int, float, bool)) or value is None:
+            return value
+
+        return str(value)
+
+    return _scrub(payload, max_depth)
+
+
+__all__ = ["cli_request_context", "logger", "scrub_for_logging"]

--- a/tests/services/generator/test_observability.py
+++ b/tests/services/generator/test_observability.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+import structlog
+
+from pydantic import BaseModel
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from services.generator.observability import cli_request_context, scrub_for_logging
+from shared.observability.logger import get_request_id
+
+
+@dataclass
+class ExampleRecord:
+    name: str
+    age: int
+
+
+class ExampleModel(BaseModel):
+    payload: dict[str, str]
+
+
+def test_scrub_for_logging_redacts_strings() -> None:
+    payload = {
+        "patient": "John Doe",
+        "age": 42,
+        "notes": ["Sensitive", "Another secret"],
+    }
+
+    sanitized = scrub_for_logging(payload)
+
+    assert sanitized["patient"] == "[redacted]"
+    assert sanitized["age"] == 42
+    assert sanitized["notes"] == ["[redacted]", "[redacted]"]
+
+
+def test_scrub_for_logging_respects_allowed_keys() -> None:
+    payload = {"hint": "SAFE", "secret": "value"}
+
+    sanitized = scrub_for_logging(payload, allow_keys={"hint"})
+
+    assert sanitized["hint"] == "SAFE"
+    assert sanitized["secret"] == "[redacted]"
+
+
+def test_scrub_for_logging_handles_dataclasses_and_models() -> None:
+    record = ExampleRecord(name="Alice", age=30)
+    model = ExampleModel(payload={"token": "abc123"})
+
+    sanitized_record = scrub_for_logging(record)
+    sanitized_model = scrub_for_logging(model)
+
+    assert sanitized_record["name"] == "[redacted]"
+    assert sanitized_record["age"] == 30
+    assert sanitized_model["payload"]["token"] == "[redacted]"
+
+
+def test_cli_request_context_binds_request_metadata() -> None:
+    with cli_request_context(operation="demo") as request_id:
+        assert request_id == get_request_id()
+        context = structlog.contextvars.get_contextvars()
+        assert context["operation"] == "demo"
+        assert context["channel"] == "cli"
+
+    remaining = structlog.contextvars.get_contextvars()
+    assert "operation" not in remaining
+    assert "channel" not in remaining


### PR DESCRIPTION
## Summary
- configure generator logging at import time and expose module-level observability helpers
- add a reusable scrubbing helper and CLI request-context utility for generator workflows
- cover generator observability helpers with unit tests

## Testing
- pytest tests/services/generator/test_observability.py

------
https://chatgpt.com/codex/tasks/task_e_68dd4f77d5f4833099c3afa5bb591141