### PR TITLE
Add patient data models for generator service

### DIFF
--- a/services/generator/models/__init__.py
+++ b/services/generator/models/__init__.py
@@ -1,0 +1,10 @@
+"""Data models used by the generator service."""
+
+from .patient import PatientRecord, Gender, PatientStatus, PatientSeed
+
+__all__ = [
+    "Gender",
+    "PatientStatus",
+    "PatientSeed",
+    "PatientRecord",
+]

--- a/services/generator/models/patient.py
+++ b/services/generator/models/patient.py
@@ -1,0 +1,151 @@
+"""Patient models for the generator service."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from enum import Enum
+from typing import Any, Dict, Iterator, Tuple
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+def _utcnow() -> datetime:
+    """Return a naive UTC timestamp compatible with ``timestamp`` columns."""
+
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+class Gender(str, Enum):
+    """Enumerated values accepted by the ``public.gender`` type."""
+
+    MALE = "male"
+    FEMALE = "female"
+    UNKNOWN = "unknown"
+
+
+class PatientStatus(str, Enum):
+    """Enumerated values accepted by the ``public.patient_status`` type."""
+
+    ACTIVE = "Active"
+    DISCHARGED = "Discharged"
+    PENDING = "Pending"
+    UNKNOWN = "Unknown"
+
+
+class PatientSeed(BaseModel):
+    """Subset of fields participating in patient uniqueness constraints."""
+
+    model_config = ConfigDict(populate_by_name=True, frozen=True)
+
+    facility_id: UUID = Field(description="Identifier of the owning facility")
+    ehr_instance_id: UUID | None = Field(
+        default=None, description="Identifier of the source EHR instance"
+    )
+    ehr_external_id: str | None = Field(
+        default=None, description="Source system identifier for the patient"
+    )
+
+    @model_validator(mode="after")
+    def validate_uniqueness(self) -> "PatientSeed":
+        """Ensure the seed fields are either fully populated or omitted."""
+
+        if (self.ehr_instance_id is None) ^ (self.ehr_external_id is None):
+            raise ValueError(
+                "ehr_instance_id and ehr_external_id must both be provided or omitted"
+            )
+        return self
+
+    def as_tuple(self) -> Tuple[UUID, UUID | None, str | None]:
+        """Return a tuple suitable for deterministic hashing."""
+
+        return (self.facility_id, self.ehr_instance_id, self.ehr_external_id)
+
+
+class PatientRecord(BaseModel):
+    """Representation of the patient columns required by the generator."""
+
+    model_config = ConfigDict(populate_by_name=True, validate_assignment=True)
+
+    id: UUID = Field(default_factory=uuid4)
+    tenant_id: UUID = Field(description="Identifier of the owning tenant")
+    seed: PatientSeed = Field(description="Seed fields enforcing uniqueness constraints")
+    name_first: str = Field(description="Patient given name")
+    name_last: str = Field(description="Patient family name")
+    gender: Gender = Field(description="Patient gender enum value")
+    status: PatientStatus = Field(description="Patient status enum value")
+    ehr_connection_status: str | None = Field(default=None)
+    ehr_last_full_manual_sync_at: datetime | None = Field(default=None)
+    dob: date | None = Field(default=None)
+    ethnicity_description: str | None = Field(default=None)
+    legal_mailing_address: Dict[str, Any] | None = Field(default=None)
+    photo_url: str | None = Field(default=None)
+    unit_description: str | None = Field(default=None)
+    floor_description: str | None = Field(default=None)
+    room_description: str | None = Field(default=None)
+    bed_description: str | None = Field(default=None)
+    admission_time: datetime | None = Field(default=None)
+    discharge_time: datetime | None = Field(default=None)
+    death_time: datetime | None = Field(default=None)
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+    @property
+    def facility_id(self) -> UUID:
+        """Proxy to the facility identifier within :class:`PatientSeed`."""
+
+        return self.seed.facility_id
+
+    @property
+    def ehr_instance_id(self) -> UUID | None:
+        """Proxy to the optional EHR instance identifier."""
+
+        return self.seed.ehr_instance_id
+
+    @property
+    def ehr_external_id(self) -> str | None:
+        """Proxy to the optional EHR external identifier."""
+
+        return self.seed.ehr_external_id
+
+    def uniqueness_seed(self) -> Tuple[UUID, UUID | None, str | None]:
+        """Return the tuple that participates in the database unique index."""
+
+        return self.seed.as_tuple()
+
+    def sql_parameter_items(
+        self, *, include_primary_key: bool = True
+    ) -> Iterator[Tuple[str, Any]]:
+        """Iterate over non-null column/value pairs for SQL operations."""
+
+        column_map: Dict[str, Any] = self.model_dump(exclude={"seed"})
+        column_map.update(
+            {
+                "facility_id": self.facility_id,
+                "ehr_instance_id": self.ehr_instance_id,
+                "ehr_external_id": self.ehr_external_id,
+            }
+        )
+
+        for column, value in column_map.items():
+            if not include_primary_key and column == "id":
+                continue
+            if value is None:
+                continue
+            if isinstance(value, Enum):
+                yield column, value.value
+            else:
+                yield column, value
+
+    def as_sql_parameters(self, *, include_primary_key: bool = True) -> Dict[str, Any]:
+        """Return a mapping of column names to non-null SQL parameters."""
+
+        return dict(self.sql_parameter_items(include_primary_key=include_primary_key))
+
+
+__all__ = [
+    "Gender",
+    "PatientStatus",
+    "PatientSeed",
+    "PatientRecord",
+]

--- a/tests/services/generator/test_models_patient.py
+++ b/tests/services/generator/test_models_patient.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from pathlib import Path
+from uuid import uuid4
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from services.generator.models import (
+    Gender,
+    PatientRecord,
+    PatientSeed,
+    PatientStatus,
+)
+
+
+def _build_seed(include_ehr: bool = True) -> PatientSeed:
+    facility_id = uuid4()
+    if include_ehr:
+        return PatientSeed(
+            facility_id=facility_id,
+            ehr_instance_id=uuid4(),
+            ehr_external_id="external-123",
+        )
+    return PatientSeed(facility_id=facility_id)
+
+
+def test_patient_record_serializes_sql_parameters() -> None:
+    patient = PatientRecord(
+        tenant_id=uuid4(),
+        seed=_build_seed(),
+        name_first="Alice",
+        name_last="Smith",
+        gender=Gender.FEMALE,
+        status=PatientStatus.ACTIVE,
+        dob=date(1990, 1, 1),
+        admission_time=datetime(2024, 1, 1, 9, 30, 0),
+    )
+
+    params = patient.as_sql_parameters()
+
+    assert params["tenant_id"] == patient.tenant_id
+    assert params["facility_id"] == patient.facility_id
+    assert params["ehr_instance_id"] == patient.ehr_instance_id
+    assert params["ehr_external_id"] == patient.ehr_external_id
+    assert params["gender"] == Gender.FEMALE.value
+    assert params["status"] == PatientStatus.ACTIVE.value
+    assert "seed" not in params
+
+
+def test_patient_record_sql_parameters_respects_primary_key_flag() -> None:
+    patient = PatientRecord(
+        tenant_id=uuid4(),
+        seed=_build_seed(include_ehr=False),
+        name_first="Bob",
+        name_last="Jones",
+        gender=Gender.MALE,
+        status=PatientStatus.PENDING,
+    )
+
+    params = patient.as_sql_parameters(include_primary_key=False)
+
+    assert "id" not in params
+    assert params["facility_id"] == patient.facility_id
+    assert "ehr_instance_id" not in params
+    assert "ehr_external_id" not in params
+
+
+def test_uniqueness_seed_matches_seed_values() -> None:
+    patient = PatientRecord(
+        tenant_id=uuid4(),
+        seed=_build_seed(),
+        name_first="Dana",
+        name_last="Lee",
+        gender=Gender.UNKNOWN,
+        status=PatientStatus.DISCHARGED,
+    )
+
+    assert patient.uniqueness_seed() == (
+        patient.facility_id,
+        patient.ehr_instance_id,
+        patient.ehr_external_id,
+    )
+
+
+def test_patient_seed_requires_matching_ehr_identifiers() -> None:
+    with pytest.raises(ValidationError):
+        PatientSeed(facility_id=uuid4(), ehr_instance_id=uuid4())
+
+    with pytest.raises(ValidationError):
+        PatientSeed(facility_id=uuid4(), ehr_external_id="abc")
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("gender", "invalid"),
+        ("status", "not-a-status"),
+    ],
+)
+def test_patient_record_enforces_enum_values(field: str, value: str) -> None:
+    data = {
+        "tenant_id": uuid4(),
+        "seed": _build_seed(),
+        "name_first": "Casey",
+        "name_last": "Taylor",
+        "gender": Gender.UNKNOWN,
+        "status": PatientStatus.UNKNOWN,
+    }
+    data[field] = value
+
+    with pytest.raises(ValidationError):
+        PatientRecord(**data)


### PR DESCRIPTION
## Summary
- add Pydantic models that capture generator patient columns and enum validation
- include SQL serialization helpers and uniqueness seed enforcement on patient records
- cover the new models with unit tests for validation and parameter mapping

## Testing
- pytest tests/services/generator

------
https://chatgpt.com/codex/tasks/task_e_68dd5348f8ac8330a27b17d7cc250c8b