### PR TITLE
Add patient resource models for generator inserts

### DIFF
--- a/services/generator/models/__init__.py
+++ b/services/generator/models/__init__.py
@@ -1,10 +1,43 @@
 """Data models used by the generator service."""
 
-from .patient import PatientRecord, Gender, PatientStatus, PatientSeed
+from .patient import (
+    EHRConnectionStatus,
+    Gender,
+    PatientRecord,
+    PatientSeed,
+    PatientStatus,
+)
+from .patient_records import (
+    AllergyCategory,
+    AllergyClinicalStatus,
+    AllergySeverity,
+    AllergyType,
+    ConditionClinicalStatus,
+    MedicationStatus,
+    PatientAllergyRecord,
+    PatientConditionRecord,
+    PatientCoverageRecord,
+    PatientMedicationRecord,
+    PatientObservationRecord,
+    PayerType,
+)
 
 __all__ = [
+    "AllergyCategory",
+    "AllergyClinicalStatus",
+    "AllergySeverity",
+    "AllergyType",
+    "ConditionClinicalStatus",
+    "EHRConnectionStatus",
     "Gender",
-    "PatientStatus",
-    "PatientSeed",
+    "MedicationStatus",
+    "PatientAllergyRecord",
+    "PatientConditionRecord",
+    "PatientCoverageRecord",
+    "PatientMedicationRecord",
+    "PatientObservationRecord",
     "PatientRecord",
+    "PatientSeed",
+    "PatientStatus",
+    "PayerType",
 ]

--- a/services/generator/models/patient_records.py
+++ b/services/generator/models/patient_records.py
@@ -1,0 +1,249 @@
+"""Patient-associated resource models for SQL generation."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from enum import Enum
+from typing import Any, Dict
+from uuid import UUID, uuid4
+
+from pydantic import Field, model_validator
+
+from .patient import EHRConnectionStatus, SQLInsertModel, _utcnow
+
+
+class AllergyCategory(str, Enum):
+    """Enumerated values accepted by the ``public.allergy_category`` type."""
+
+    DRUG = "Drug"
+    FOOD = "Food"
+    ENVIRONMENTAL = "Environmental"
+    SUBSTANCE = "Substance"
+    OTHER = "Other"
+    UNKNOWN = "Unknown"
+
+
+class AllergyClinicalStatus(str, Enum):
+    """Enumerated values accepted by the ``public.allergy_clinical_status`` type."""
+
+    ACTIVE = "Active"
+    RESOLVED = "Resolved"
+    PRIOR_HISTORY = "PriorHistory"
+    UNKNOWN = "Unknown"
+
+
+class AllergySeverity(str, Enum):
+    """Enumerated values accepted by the ``public.allergy_severity`` type."""
+
+    MILD = "Mild"
+    MODERATE = "Moderate"
+    SEVERE = "Severe"
+    UNKNOWN = "Unknown"
+
+
+class AllergyType(str, Enum):
+    """Enumerated values accepted by the ``public.allergy_type`` type."""
+
+    ALLERGY = "Allergy"
+    INTOLERANCE = "Intolerance"
+    PROPENSITY_TO_ADVERSE_REACTIONS = "PropensityToAdverseReactions"
+    UNKNOWN = "Unknown"
+
+
+class ConditionClinicalStatus(str, Enum):
+    """Enumerated values accepted by the ``public.condition_clinical_status`` type."""
+
+    ACTIVE = "Active"
+    RESOLVED = "Resolved"
+    UNKNOWN = "Unknown"
+
+
+class MedicationStatus(str, Enum):
+    """Enumerated values accepted by the ``public.medication_status`` type."""
+
+    INITIAL = "Initial"
+    ACTIVE = "Active"
+    ON_HOLD = "OnHold"
+    COMPLETED = "Completed"
+    DISCONTINUED = "Discontinued"
+    STRUCK_OUT = "StruckOut"
+    UNVERIFIED = "Unverified"
+    UNCONFIRMED = "Unconfirmed"
+    PENDING_REVIEW = "PendingReview"
+    PENDING_MARK_TO_SIGN = "PendingMarkToSign"
+    PENDING_SIGNATURE = "PendingSignature"
+    HISTORICAL = "Historical"
+    DRAFT = "Draft"
+    UNKNOWN = "Unknown"
+
+
+class PayerType(str, Enum):
+    """Enumerated values accepted by the ``public.payer_type`` type."""
+
+    MANAGED_CARE = "ManagedCare"
+    MEDICAID = "Medicaid"
+    MEDICARE_A = "MedicareA"
+    MEDICARE_B = "MedicareB"
+    MEDICARE_D = "MedicareD"
+    OTHER = "Other"
+    OUTPATIENT = "Outpatient"
+    PRIVATE = "Private"
+    UNKNOWN = "Unknown"
+
+
+class _EHRLinkedRecord(SQLInsertModel):
+    """Base class enforcing shared EHR linkage validations."""
+
+    patient_id: UUID = Field(description="Identifier referencing public.patient")
+    ehr_instance_id: UUID | None = Field(
+        default=None, description="Identifier referencing public.ehr_instance"
+    )
+    ehr_external_id: str | None = Field(
+        default=None, description="External identifier from the source EHR"
+    )
+    ehr_connection_status: EHRConnectionStatus | None = Field(
+        default=None, description="Connection status reported by the EHR"
+    )
+
+    @model_validator(mode="after")
+    def _validate_ehr_linkage(self) -> "_EHRLinkedRecord":
+        if (self.ehr_instance_id is None) ^ (self.ehr_external_id is None):
+            raise ValueError(
+                "ehr_instance_id and ehr_external_id must both be provided or omitted"
+            )
+        if self.ehr_connection_status is not None and (
+            self.ehr_instance_id is None or self.ehr_external_id is None
+        ):
+            raise ValueError(
+                "ehr_connection_status requires ehr_instance_id and ehr_external_id"
+            )
+        return self
+
+
+class PatientAllergyRecord(_EHRLinkedRecord):
+    """Representation of the ``public.patient_allergy`` table."""
+
+    id: UUID = Field(default_factory=uuid4)
+    allergen: str = Field(description="Name of the allergen")
+    category: AllergyCategory = Field(
+        default=AllergyCategory.UNKNOWN,
+        description="Allergy category enum value",
+    )
+    clinical_status: AllergyClinicalStatus = Field(
+        description="Clinical status enum value"
+    )
+    created_by: str | None = Field(default=None)
+    created_time: datetime | None = Field(default=None)
+    onset_date: date | None = Field(default=None)
+    reaction_note: str | None = Field(default=None)
+    reaction_type: str | None = Field(default=None)
+    reaction_sub_type: str | None = Field(default=None)
+    resolved_date: date | None = Field(default=None)
+    rev_by: str | None = Field(default=None)
+    rev_time: datetime | None = Field(default=None)
+    severity: AllergySeverity = Field(
+        default=AllergySeverity.UNKNOWN,
+        description="Allergy severity enum value",
+    )
+    type: AllergyType = Field(
+        default=AllergyType.UNKNOWN, description="Allergy type enum value"
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class PatientConditionRecord(_EHRLinkedRecord):
+    """Representation of the ``public.patient_condition`` table."""
+
+    id: UUID = Field(default_factory=uuid4)
+    classification_description: str | None = Field(default=None)
+    clinical_status: ConditionClinicalStatus = Field(
+        description="Condition clinical status enum value"
+    )
+    comments: str | None = Field(default=None)
+    created_by: str | None = Field(default=None)
+    created_time: datetime | None = Field(default=None)
+    icd_10_code: str | None = Field(default=None)
+    icd_10_description: str | None = Field(default=None)
+    onset_date: date | None = Field(default=None)
+    is_primary_diagnosis: bool = Field(
+        description="Indicates the primary diagnosis flag"
+    )
+    resolved_date: date | None = Field(default=None)
+    rev_by: str | None = Field(default=None)
+    rev_time: datetime | None = Field(default=None)
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class PatientCoverageRecord(_EHRLinkedRecord):
+    """Representation of the ``public.patient_coverage`` table."""
+
+    id: UUID = Field(default_factory=uuid4)
+    payer_name: str = Field(description="Name of the payer")
+    payer_type: PayerType = Field(description="Payer type enum value")
+    payer_rank: int = Field(description="Rank of the coverage")
+    payer_code: str | None = Field(default=None)
+    payer_code_2: str | None = Field(default=None)
+    informational_only: bool = Field(default=False)
+    effective_time: datetime = Field(description="Coverage effective timestamp")
+    expiration_time: datetime | None = Field(default=None)
+    account_number: str | None = Field(default=None)
+    account_description: str | None = Field(default=None)
+    issuer: Dict[str, Any] | None = Field(default=None)
+    insured_party: Dict[str, Any] | None = Field(default=None)
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class PatientMedicationRecord(_EHRLinkedRecord):
+    """Representation of the ``public.patient_medication`` table."""
+
+    id: UUID = Field(default_factory=uuid4)
+    created_by: str | None = Field(default=None)
+    created_time: datetime | None = Field(default=None)
+    description: str = Field(default="Missing")
+    directions: str = Field(default="Missing")
+    discontinued_time: datetime | None = Field(default=None)
+    end_time: date | None = Field(default=None)
+    generic_name: str | None = Field(default=None)
+    narcotic: bool | None = Field(default=None)
+    order_time: datetime | None = Field(default=None)
+    physician_details: Dict[str, Any] | None = Field(default=None)
+    rev_by: str | None = Field(default=None)
+    rev_time: datetime | None = Field(default=None)
+    rx_norm_id: str | None = Field(default=None)
+    start_time: date | None = Field(default=None)
+    status: MedicationStatus = Field(description="Medication status enum value")
+    strength: str | None = Field(default=None)
+    strength_unit: str | None = Field(default=None)
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class PatientObservationRecord(_EHRLinkedRecord):
+    """Representation of the ``public.patient_observation`` table."""
+
+    id: UUID = Field(default_factory=uuid4)
+    method: str | None = Field(default=None)
+    recorded_by: str | None = Field(default=None)
+    recorded_time: datetime | None = Field(default=None)
+    data: Dict[str, Any] = Field(description="Observation payload as JSON")
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+__all__ = [
+    "AllergyCategory",
+    "AllergyClinicalStatus",
+    "AllergySeverity",
+    "AllergyType",
+    "ConditionClinicalStatus",
+    "MedicationStatus",
+    "PayerType",
+    "PatientAllergyRecord",
+    "PatientConditionRecord",
+    "PatientCoverageRecord",
+    "PatientMedicationRecord",
+    "PatientObservationRecord",
+]

--- a/tests/services/generator/test_models_patient.py
+++ b/tests/services/generator/test_models_patient.py
@@ -43,7 +43,7 @@ def test_patient_record_serializes_sql_parameters() -> None:
         admission_time=datetime(2024, 1, 1, 9, 30, 0),
     )
 
-    params = patient.as_sql_parameters()
+    params = patient.as_parameters()
 
     assert params["tenant_id"] == patient.tenant_id
     assert params["facility_id"] == patient.facility_id
@@ -64,7 +64,7 @@ def test_patient_record_sql_parameters_respects_primary_key_flag() -> None:
         status=PatientStatus.PENDING,
     )
 
-    params = patient.as_sql_parameters(include_primary_key=False)
+    params = patient.as_parameters(include_primary_key=False)
 
     assert "id" not in params
     assert params["facility_id"] == patient.facility_id

--- a/tests/services/generator/test_models_patient_records.py
+++ b/tests/services/generator/test_models_patient_records.py
@@ -1,0 +1,119 @@
+import sys
+from datetime import datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from services.generator.models import (
+    AllergyCategory,
+    AllergyClinicalStatus,
+    AllergySeverity,
+    AllergyType,
+    EHRConnectionStatus,
+    MedicationStatus,
+    PatientAllergyRecord,
+    PatientCoverageRecord,
+    PatientMedicationRecord,
+    PayerType,
+)
+
+
+def _ehr_kwargs() -> dict:
+    return {
+        "ehr_instance_id": uuid4(),
+        "ehr_external_id": "ehr-123",
+        "ehr_connection_status": EHRConnectionStatus.CONNECTED,
+    }
+
+
+def test_ehr_linkage_requires_matching_identifiers() -> None:
+    base = {
+        "patient_id": uuid4(),
+        "allergen": "Peanuts",
+        "clinical_status": AllergyClinicalStatus.ACTIVE,
+    }
+
+    with pytest.raises(ValidationError):
+        PatientAllergyRecord(**base, ehr_instance_id=uuid4())
+
+    with pytest.raises(ValidationError):
+        PatientAllergyRecord(**base, ehr_external_id="abc")
+
+    with pytest.raises(ValidationError):
+        PatientAllergyRecord(
+            **base,
+            ehr_connection_status=EHRConnectionStatus.CONNECTED,
+        )
+
+
+def test_patient_allergy_serializes_parameters() -> None:
+    allergy = PatientAllergyRecord(
+        patient_id=uuid4(),
+        allergen="Peanuts",
+        clinical_status=AllergyClinicalStatus.ACTIVE,
+        category=AllergyCategory.FOOD,
+        severity=AllergySeverity.SEVERE,
+        type=AllergyType.ALLERGY,
+        onset_date=datetime(2023, 1, 1, 12, 0, 0).date(),
+        **_ehr_kwargs(),
+    )
+
+    params = allergy.as_parameters(include_primary_key=False)
+
+    assert "id" not in params
+    assert params["allergen"] == "Peanuts"
+    assert params["category"] == AllergyCategory.FOOD.value
+    assert params["severity"] == AllergySeverity.SEVERE.value
+    assert params["type"] == AllergyType.ALLERGY.value
+    assert params["ehr_connection_status"] == EHRConnectionStatus.CONNECTED.value
+
+
+def test_patient_medication_defaults_and_serialization() -> None:
+    medication = PatientMedicationRecord(
+        patient_id=uuid4(),
+        status=MedicationStatus.ACTIVE,
+        **_ehr_kwargs(),
+    )
+
+    params = medication.as_parameters()
+
+    assert params["description"] == "Missing"
+    assert params["directions"] == "Missing"
+    assert params["status"] == MedicationStatus.ACTIVE.value
+
+
+def test_patient_coverage_requires_effective_time() -> None:
+    with pytest.raises(ValidationError):
+        PatientCoverageRecord(
+            patient_id=uuid4(),
+            payer_name="InsureCo",
+            payer_type=PayerType.PRIVATE,
+            payer_rank=1,
+            **_ehr_kwargs(),
+        )
+
+
+def test_patient_coverage_serializes_json_fields() -> None:
+    coverage = PatientCoverageRecord(
+        patient_id=uuid4(),
+        payer_name="InsureCo",
+        payer_type=PayerType.PRIVATE,
+        payer_rank=1,
+        effective_time=datetime(2024, 1, 1, 0, 0, 0),
+        issuer={"name": "InsureCo"},
+        insured_party={"name": "John Doe"},
+        **_ehr_kwargs(),
+    )
+
+    params = coverage.as_parameters(include_primary_key=False)
+
+    assert "id" not in params
+    assert params["issuer"] == {"name": "InsureCo"}
+    assert params["insured_party"] == {"name": "John Doe"}
+    assert params["payer_type"] == PayerType.PRIVATE.value


### PR DESCRIPTION
## Summary
- add a reusable SQL insert mixin and expose the EHR connection status enum for generator models
- implement patient_* resource models that enforce foreign key linkage and enum constraints while standardising SQL parameters
- expand generator service tests to cover the new helper methods and validation rules

## Testing
- pytest tests/services/generator -q

------
https://chatgpt.com/codex/tasks/task_e_68dd5621cb20833082863bb78f1583e4